### PR TITLE
feat: Iron Law, rationalization prevention, and verification gates (v1.1)

### DIFF
--- a/skills/reviewing-code-claude/SKILL.md
+++ b/skills/reviewing-code-claude/SKILL.md
@@ -4,13 +4,34 @@ description: Performs a structured code and documentation review using a severit
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git and gh CLI.
 metadata:
   author: gregoryfoster
-  version: "1.0"
+  version: "1.1"
   triggers: CR, code review, perform a review
 ---
 
 # Code & Documentation Review
 
 A systematic review workflow that produces a numbered findings report, waits for directives, then implements approved changes.
+
+## The Iron Law
+
+```
+NO FINDINGS REPORT WITHOUT RUNNING THE TEST SUITE FIRST
+NO CHANGES WITHOUT A FINDINGS REPORT AND EXPLICIT USER DIRECTIVES
+```
+
+If you haven't run `gather-context.sh` and confirmed tests pass, you have not completed Phase 1.
+If the user hasn't responded with directives, you cannot implement anything.
+
+## Rationalization prevention
+
+| Thought | Reality |
+|---|---|
+| "It's a small change, no need for a full review" | Size doesn't determine risk. Run the review. |
+| "I just implemented this, I know it's correct" | Familiarity bias. A fresh pass finds what implementation blindness missed. |
+| "Tests are passing, that's the review" | Tests verify behavior, not convention compliance or docs. |
+| "The user seems in a hurry" | A fast broken change is slower than a thorough correct one. |
+| "I'll fix things as I find them" | Phase 4 exists. Present first, implement after directives. |
+| "This file wasn't in the diff" | Related files need review too. Check call sites, tests, AGENTS.md. |
 
 ## Scope detection
 
@@ -55,13 +76,23 @@ Key rules:
 - Group by severity: 🔴 Bugs → 🟡 Issues to fix → 💭 Minor/observations
 - **Summary** — 1–2 sentences on overall assessment and top priorities
 
+### Phase 3.5 — Verify before reporting
+
+```
+NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION
+```
+
+- Re-run tests if any implementation happened in this conversation
+- If tests fail: report the failure as a 🔴 finding regardless of cause
+- Do NOT claim "tests pass" unless you have output from this session confirming it
+
 ### Phase 4 — Wait for feedback
 
 **Stop. Do not make changes until the user responds.**
 
 Accept terse directives referencing item numbers. See [references/directives.md](references/directives.md).
 
-After directives, implement all requested changes, commit, and present a summary table.
+After directives, implement all requested changes. Before committing, run the test suite and confirm it passes — report any failures before committing. Then commit and present a summary table.
 
 ## Second review rounds
 

--- a/skills/shipping-work-claude/SKILL.md
+++ b/skills/shipping-work-claude/SKILL.md
@@ -4,13 +4,30 @@ description: "Finalizes work by ensuring everything is committed, pushed to the 
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git and gh CLI.
 metadata:
   author: gregoryfoster
-  version: "1.0"
+  version: "1.1"
   triggers: ship it, push GH, close GH, wrap up
 ---
 
 # Shipping Work
 
 Finalizes work: clean commit, push, GitHub issue comments, and closure.
+
+## The Iron Law
+
+```
+NO PUSH WITHOUT PASSING TESTS — VERIFIED IN THIS SESSION
+NO ISSUE CLOSURE WITHOUT FULL IMPLEMENTATION — VERIFIED AGAINST ORIGINAL REQUIREMENTS
+```
+
+## Rationalization prevention
+
+| Thought | Reality |
+|---|---|
+| "Tests passed earlier in this session" | Run them again. State can change. Require fresh output. |
+| "It's basically done, just needs minor cleanup" | Incomplete = not done. Finish or explicitly descope before closing. |
+| "The issue will track follow-up work" | Only close if the core requirement is fully met. Open a new issue for follow-up. |
+| "gh push is failing, I'll skip it" | Resolve the error. Do not mark as shipped without a successful push. |
+| "User is in a hurry" | A bad ship is slower than a good one. Run the checklist. |
 
 ## Scope detection
 
@@ -23,7 +40,15 @@ Determine which GitHub issue(s) to close (priority order):
 
 ### Step 1 — Run tests
 
-If tests haven't been run this session, run them now before proceeding. Do not push failing tests.
+```bash
+bash scripts/pre-ship.sh
+```
+
+```
+NO CONTINUATION IF TESTS FAIL
+```
+
+If tests fail: stop, report the failure, fix before proceeding. Do not push failing code under any circumstances.
 
 ### Step 2 — Ensure a clean working tree
 
@@ -65,11 +90,16 @@ Comment must include:
 
 ### Step 6 — Close GitHub issues
 
+<HARD-GATE>
+Before closing any issue, verify the original requirements against what was implemented:
+1. Re-read the issue body
+2. Confirm each stated requirement is addressed in commits
+3. If any requirement is missing: do NOT close — ask the user whether to descope or continue
+</HARD-GATE>
+
 ```bash
 bash scripts/close-issue.sh <number>
 ```
-
-Never close an issue that wasn't fully implemented — ask first if uncertain.
 
 ### Step 7 — Report
 


### PR DESCRIPTION
## Summary

Adds enforcement patterns to `reviewing-code-claude` and `shipping-work-claude`, learned from integrating [`obra/superpowers`](https://github.com/obra/superpowers) into a downstream project.

No project-specific content — all changes are generic and apply across projects using these skills.

---

## `reviewing-code-claude` (v1.0 → v1.1)

**Iron Law** — explicit preconditions stated at the top of the skill:
```
NO FINDINGS REPORT WITHOUT RUNNING THE TEST SUITE FIRST
NO CHANGES WITHOUT A FINDINGS REPORT AND EXPLICIT USER DIRECTIVES
```

**Rationalization prevention table** — 6 common skip-rationalizations mapped to reality (e.g. "It's a small change" → "Size doesn't determine risk").

**Phase 3.5 — Verify before reporting** — explicit gate: no "tests pass" claim without output from the current session confirming it; test failures surface as 🔴 findings.

**Post-directive verification** — require test run before committing after implementing fixes.

---

## `shipping-work-claude` (v1.0 → v1.1)

**Iron Law** — explicit preconditions at the top:
```
NO PUSH WITHOUT PASSING TESTS — VERIFIED IN THIS SESSION
NO ISSUE CLOSURE WITHOUT FULL IMPLEMENTATION — VERIFIED AGAINST ORIGINAL REQUIREMENTS
```

**Rationalization prevention table** — 5 common skip-rationalizations (e.g. "Tests passed earlier" → "Run them again. State can change.").

**Step 1** — strengthened: explicit `pre-ship.sh` invocation with hard stop language replacing the softer "if tests haven't been run" phrasing.

**Step 6 — `<HARD-GATE>`** — requires re-reading the issue body and confirming each stated requirement is addressed before closing; if anything is missing, stop and ask.

---

## Motivation

These patterns were battle-tested in `obra/superpowers` (Iron Laws, HARD-GATEs, rationalization-prevention tables). They address real failure modes:
- Agent skips review because the change "seems small"
- Agent claims "tests pass" based on a run from earlier in the session
- Agent closes an issue when only part of the requirements were implemented

The `<HARD-GATE>` syntax is borrowed from `obra/superpowers:brainstorming` where it proved semantically clear to agents reading the skill.