### PR TITLE
#46 feat: skills-doctor + opportunistic install via auto-refresh hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,7 @@ Key rules:
 - Symlink paths must be relative: `../../skills-vendor/gregoryfoster-skills/skills/<skill-name>`
 - Local overrides (committed directories in `skills/`) always win over symlinks
 - The `skills-vendor/` directory is read-only from the consuming project's perspective
+- Install `.skills/doctor.sh` via `bash skills-vendor/<owner>-<repo>/skills/managing-skills/scripts/install-doctor.sh` — Phase 1 of `reviewing-*` / `shipping-*` skills uses it to self-heal dangling vendor symlinks. The auto-refresh hook re-installs it opportunistically; the manual command is only needed before the first session.
 
 The [`managing-skills`](skills/managing-skills/) skill teaches agents how to perform these operations.
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,12 @@ mkdir -p skills
 ln -s ../../skills-vendor/gregoryfoster-skills/skills/reviewing-code skills/reviewing-code
 ln -s ../../skills-vendor/gregoryfoster-skills/skills/shipping-work skills/shipping-work
 
-# 3. Commit
-git add .gitmodules skills-vendor/gregoryfoster-skills skills/
+# 3. Install the doctor preflight (self-heals dangling symlinks in fresh
+#    worktrees, shallow CI clones, etc.)
+bash skills-vendor/gregoryfoster-skills/skills/managing-skills/scripts/install-doctor.sh
+
+# 4. Commit
+git add .gitmodules skills-vendor/gregoryfoster-skills skills/ .skills/doctor.sh
 git commit -m "feat: add gregoryfoster/skills submodule"
 ```
 

--- a/skills/managing-skills/SKILL.md
+++ b/skills/managing-skills/SKILL.md
@@ -4,7 +4,7 @@ description: "Manages external skill repos in a project using the git submodule 
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git CLI.
 metadata:
   author: gregoryfoster
-  version: "1.3"
+  version: "1.4"
   triggers: add skill repo, add external skills, manage skills, update vendor skills, install skills hook, enable auto-refresh
 ---
 
@@ -71,6 +71,18 @@ ln -s ../../skills/shipping-work .claude/skills/shipping-work
 
 The `../../` prefix resolves from `.claude/skills/` back to the project root, then into `skills/<name>`.
 
+#### Step 2c — Install the doctor script
+
+Skills referenced via the symlink chain (`.claude/skills/<name>` → `../../skills/<name>` → `../skills-vendor/.../skills/<name>`) are unreachable when the submodule isn't initialized — fresh `git worktree add`, shallow CI clones without `--recurse-submodules`, etc. The doctor is a tiny script copied into the consumer's `.skills/` directory that walks `skills/*` symlinks, auto-runs `git submodule update --init --recursive` when any dangle, and prints an actionable error otherwise. Phase 1 of every `reviewing-*` / `shipping-*` skill invokes it as a preflight.
+
+Run the installer from the vendor copy:
+
+```bash
+bash skills-vendor/<owner>-<repo>/skills/managing-skills/scripts/install-doctor.sh
+```
+
+This is idempotent — re-running is a no-op when the destination already matches. The installer refuses to clobber a file at `.skills/doctor.sh` that doesn't look like a doctor, so a user-authored file at that path is never silently overwritten.
+
 #### Step 3 — Update the project's AGENTS.md
 
 Add or update the `<available_skills>` block to list the newly available skills. Document which skills are symlinked (global) vs local overrides.
@@ -80,7 +92,7 @@ Add or update the `<available_skills>` block to list the newly available skills.
 Commit the `.gitmodules` file, the `skills-vendor/` submodule reference, and the new symlinks together:
 
 ```bash
-git add .gitmodules skills-vendor/<owner>-<repo> skills/ .claude/skills/
+git add .gitmodules skills-vendor/<owner>-<repo> skills/ .claude/skills/ .skills/doctor.sh
 git commit -m "feat: add <owner>/<repo> skills submodule"
 ```
 
@@ -116,6 +128,12 @@ git add skills-vendor/
 git commit -m "chore: update skill submodules"
 ```
 
+After updating, re-run `install-doctor.sh` to pick up any new doctor version — the auto-refresh hook does this automatically on session start, but a manual refresh is useful when iterating outside a session:
+
+```bash
+bash skills-vendor/<owner>-<repo>/skills/managing-skills/scripts/install-doctor.sh
+```
+
 ### Installing the auto-refresh hook
 
 Pulls upstream submodule changes once per calendar day, on `main` only, and auto-commits the pointer bumps. Designed for invocation as a Claude Code `SessionStart` hook — exits `0` on every non-fatal condition so it can never block a session.
@@ -127,6 +145,7 @@ Pulls upstream submodule changes once per calendar day, on `main` only, and auto
 - Scopes updates to `skills-vendor/` — never touches other submodules a project may have.
 - Logs to `.git/skills-update.log` (auto-truncated to the last 200 lines once it crosses 64 KiB).
 - Matches diff scope to add scope (`skills-vendor/`), so unrelated dirty work cannot be absorbed and empty commits cannot be created.
+- **Opportunistically installs/updates `.skills/doctor.sh`** on every session (not gated by the once-per-day lock) so the doctor self-heals if accidentally deleted, and so consumers added before the doctor existed pick it up automatically on the next session start.
 - To verify the hook is running, check `.git/skills-update.log` after a session start on `main`. Lines beginning `unexpected hook error` come from the ERR-trap backstop and mark an unanticipated failure path; the hook still exits 0.
 
 #### Step 0 — Skip if already installed
@@ -274,6 +293,6 @@ git clone --recurse-submodules <project-url>
 ## Notes
 
 - Always use relative symlink paths so they work regardless of where the repo is cloned
-- If a symlink is broken (target missing), run `git submodule update --init`
+- If a symlink is broken (target missing), run `bash .skills/doctor.sh` — it auto-runs `git submodule update --init --recursive` and reports an actionable error if self-healing fails
 - The `skills-vendor/` directory should be treated as read-only — make changes upstream
 - The two-level chain (`.claude/skills/<name>` → `../../skills/<name>` → `../skills-vendor/…`) means any local override created in `skills/` automatically shadows the vendor version in Claude Code too — no changes to `.claude/skills/` needed

--- a/skills/managing-skills/scripts/doctor.sh
+++ b/skills/managing-skills/scripts/doctor.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# managing-skills-doctor: do not remove this marker — install-doctor.sh greps it
 # doctor.sh — diagnose and self-heal dangling skill symlinks.
 #
 # When this repo is vendored via the managing-skills git-submodule + symlink
@@ -23,7 +24,7 @@
 # Usage: bash .skills/doctor.sh [--check-only] [--verbose] [--help]
 set -euo pipefail
 
-VERSION="2026-05-25-1"
+VERSION="2026-05-26-2"
 
 CHECK_ONLY=0
 VERBOSE=0
@@ -44,7 +45,9 @@ Exits 0 silently when healthy. Exits non-zero with an actionable error
 when self-healing fails or is not possible (e.g. no .git directory).
 
 Options:
-  --check-only    Report broken symlinks but do not run submodule init.
+  --check-only    Report broken symlinks but do not run submodule init
+                  (overridden by the archive-checkout path when .git is
+                  absent — the archive case prints its own diagnosis).
   --verbose, -v   Print resolution details even when healthy.
   --version       Print script version and exit.
   --help, -h      Show this help and exit.
@@ -71,48 +74,56 @@ cd "$ROOT"
 
 # Nothing to check if the consumer doesn't use the skills/ pattern.
 if [ ! -d skills ]; then
-  [ "$VERBOSE" = "1" ] && echo "doctor: no skills/ directory — nothing to check"
+  [ "$VERBOSE" = "1" ] && echo "doctor: no skills/ directory — nothing to check" >&2
   exit 0
 fi
 
-# Collect broken top-level symlinks under skills/. A symlink is "broken"
-# when it exists but its target does not resolve to an existing path.
-# Local overrides (regular directories) are skipped — they're not symlinks.
-collect_broken() {
-  local broken=()
+# BROKEN is the output channel of scan_broken — declared at top scope so the
+# function's communication pattern is visible without reading every call
+# site. Using an array (rather than a single string) preserves
+# paths-with-spaces correctly when later expanded as "${BROKEN[@]}".
+declare -a BROKEN=()
+
+# Walks skills/* and populates BROKEN with any dangling symlinks. A symlink
+# is "broken" when it exists but its target does not resolve. Local
+# overrides (regular directories) are skipped — they're not symlinks.
+scan_broken() {
+  BROKEN=()
   local entry
   for entry in skills/*; do
     [ -L "$entry" ] || continue
     if [ ! -e "$entry" ]; then
-      broken+=("$entry")
+      BROKEN+=("$entry")
     fi
   done
-  printf '%s\n' "${broken[@]:-}"
 }
 
-BROKEN_LIST="$(collect_broken)"
+scan_broken
 
-if [ -z "$BROKEN_LIST" ]; then
-  [ "$VERBOSE" = "1" ] && echo "doctor: all skill symlinks resolve"
+if [ "${#BROKEN[@]}" -eq 0 ]; then
+  [ "$VERBOSE" = "1" ] && echo "doctor: all skill symlinks resolve" >&2
   exit 0
 fi
 
-# At least one dangling symlink. Decide whether to attempt self-heal.
-if [ "$CHECK_ONLY" = "1" ]; then
-  echo "doctor: dangling skill symlinks detected:" >&2
-  printf '  %s\n' $BROKEN_LIST >&2
-  echo "Run 'git submodule update --init --recursive' to repair." >&2
-  exit 1
-fi
-
+# At least one dangling symlink. Distinguish archive-checkout (no .git) from
+# the normal git-submodule case before either self-healing or reporting,
+# so --check-only never suggests a `git submodule` command in a checkout
+# that doesn't have a .git dir.
 if [ ! -d .git ] && [ ! -f .git ]; then
   echo "doctor: dangling skill symlinks detected and no .git directory present:" >&2
-  printf '  %s\n' $BROKEN_LIST >&2
+  printf '  %s\n' "${BROKEN[@]}" >&2
   echo "" >&2
   echo "This checkout was likely created from a source archive (zip/tarball)" >&2
   echo "rather than 'git clone'. The submodule pattern this repo uses is not" >&2
   echo "compatible with archive downloads. Clone with --recurse-submodules" >&2
   echo "instead, or vendor the skill scripts manually." >&2
+  exit 1
+fi
+
+if [ "$CHECK_ONLY" = "1" ]; then
+  echo "doctor: dangling skill symlinks detected:" >&2
+  printf '  %s\n' "${BROKEN[@]}" >&2
+  echo "Run 'git submodule update --init --recursive' to repair." >&2
   exit 1
 fi
 
@@ -123,15 +134,15 @@ if ! git submodule update --init --recursive >&2; then
 fi
 
 # Re-check after self-heal.
-BROKEN_AFTER="$(collect_broken)"
-if [ -n "$BROKEN_AFTER" ]; then
+scan_broken
+if [ "${#BROKEN[@]}" -gt 0 ]; then
   echo "doctor: symlinks still dangling after submodule init:" >&2
-  printf '  %s\n' $BROKEN_AFTER >&2
+  printf '  %s\n' "${BROKEN[@]}" >&2
   echo "" >&2
   echo "The .gitmodules entry for the vendor repo may be missing, or the" >&2
   echo "symlink target points to a path that does not exist upstream." >&2
   exit 1
 fi
 
-[ "$VERBOSE" = "1" ] && echo "doctor: self-healed; all skill symlinks resolve"
+[ "$VERBOSE" = "1" ] && echo "doctor: self-healed; all skill symlinks resolve" >&2
 exit 0

--- a/skills/managing-skills/scripts/doctor.sh
+++ b/skills/managing-skills/scripts/doctor.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# doctor.sh — diagnose and self-heal dangling skill symlinks.
+#
+# When this repo is vendored via the managing-skills git-submodule + symlink
+# pattern, a consumer checkout that hasn't initialized submodules
+# (fresh `git worktree add`, shallow CI clone, etc.) leaves the
+# .claude/skills/<name> → ../../skills/<name> → ../skills-vendor/.../<name>
+# chain dangling. Scripts referenced from SKILL.md then fail with confusing
+# "No such file or directory" errors even though the symlinks exist.
+#
+# This script is installed as a real (non-symlinked) file at
+# <repo-root>/.skills/doctor.sh so it remains reachable even when the
+# vendor chain is broken. It walks skills/* symlinks, attempts a
+# `git submodule update --init --recursive` if any dangle, and prints a
+# clear actionable error if self-healing fails.
+#
+# Designed for use as a Phase 1 preflight in every reviewing-* / shipping-*
+# SKILL.md invocation:
+#
+#   bash .skills/doctor.sh
+#   bash scripts/gather-context.sh
+#
+# Usage: bash .skills/doctor.sh [--check-only] [--verbose] [--help]
+set -euo pipefail
+
+VERSION="2026-05-25-1"
+
+CHECK_ONLY=0
+VERBOSE=0
+for arg in "$@"; do
+  case "$arg" in
+    --check-only) CHECK_ONLY=1 ;;
+    --verbose|-v) VERBOSE=1 ;;
+    --version) echo "$VERSION"; exit 0 ;;
+    --help|-h)
+      cat <<EOF
+Usage: bash .skills/doctor.sh [--check-only] [--verbose]
+
+Diagnose and self-heal dangling skill symlinks in skills/.
+
+If any skills/<name> symlink does not resolve and a .git directory is
+present, runs 'git submodule update --init --recursive' and re-checks.
+Exits 0 silently when healthy. Exits non-zero with an actionable error
+when self-healing fails or is not possible (e.g. no .git directory).
+
+Options:
+  --check-only    Report broken symlinks but do not run submodule init.
+  --verbose, -v   Print resolution details even when healthy.
+  --version       Print script version and exit.
+  --help, -h      Show this help and exit.
+
+Exit codes:
+  0  All skill symlinks resolve (or skills/ does not exist).
+  1  One or more symlinks remain broken after self-heal attempt.
+  2  Invalid invocation (e.g. unknown flag).
+EOF
+      exit 0
+      ;;
+    *)
+      echo "doctor.sh: unknown option: $arg" >&2
+      echo "Try 'bash .skills/doctor.sh --help' for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
+# Resolve the project root. The doctor is normally invoked from the repo
+# root, but we tolerate being called from a subdirectory.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+# Nothing to check if the consumer doesn't use the skills/ pattern.
+if [ ! -d skills ]; then
+  [ "$VERBOSE" = "1" ] && echo "doctor: no skills/ directory — nothing to check"
+  exit 0
+fi
+
+# Collect broken top-level symlinks under skills/. A symlink is "broken"
+# when it exists but its target does not resolve to an existing path.
+# Local overrides (regular directories) are skipped — they're not symlinks.
+collect_broken() {
+  local broken=()
+  local entry
+  for entry in skills/*; do
+    [ -L "$entry" ] || continue
+    if [ ! -e "$entry" ]; then
+      broken+=("$entry")
+    fi
+  done
+  printf '%s\n' "${broken[@]:-}"
+}
+
+BROKEN_LIST="$(collect_broken)"
+
+if [ -z "$BROKEN_LIST" ]; then
+  [ "$VERBOSE" = "1" ] && echo "doctor: all skill symlinks resolve"
+  exit 0
+fi
+
+# At least one dangling symlink. Decide whether to attempt self-heal.
+if [ "$CHECK_ONLY" = "1" ]; then
+  echo "doctor: dangling skill symlinks detected:" >&2
+  printf '  %s\n' $BROKEN_LIST >&2
+  echo "Run 'git submodule update --init --recursive' to repair." >&2
+  exit 1
+fi
+
+if [ ! -d .git ] && [ ! -f .git ]; then
+  echo "doctor: dangling skill symlinks detected and no .git directory present:" >&2
+  printf '  %s\n' $BROKEN_LIST >&2
+  echo "" >&2
+  echo "This checkout was likely created from a source archive (zip/tarball)" >&2
+  echo "rather than 'git clone'. The submodule pattern this repo uses is not" >&2
+  echo "compatible with archive downloads. Clone with --recurse-submodules" >&2
+  echo "instead, or vendor the skill scripts manually." >&2
+  exit 1
+fi
+
+echo "doctor: dangling skill symlinks detected — initializing submodules..." >&2
+if ! git submodule update --init --recursive >&2; then
+  echo "doctor: 'git submodule update --init --recursive' failed" >&2
+  exit 1
+fi
+
+# Re-check after self-heal.
+BROKEN_AFTER="$(collect_broken)"
+if [ -n "$BROKEN_AFTER" ]; then
+  echo "doctor: symlinks still dangling after submodule init:" >&2
+  printf '  %s\n' $BROKEN_AFTER >&2
+  echo "" >&2
+  echo "The .gitmodules entry for the vendor repo may be missing, or the" >&2
+  echo "symlink target points to a path that does not exist upstream." >&2
+  exit 1
+fi
+
+[ "$VERBOSE" = "1" ] && echo "doctor: self-healed; all skill symlinks resolve"
+exit 0

--- a/skills/managing-skills/scripts/install-doctor.sh
+++ b/skills/managing-skills/scripts/install-doctor.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# install-doctor.sh — copy doctor.sh into a consumer repo's .skills/ directory.
+#
+# The doctor MUST be a real file (not a symlink) at the consumer side
+# because its job is to diagnose broken vendor symlinks. A symlinked
+# doctor would itself be unreachable in the exact failure mode it's
+# meant to repair.
+#
+# This script is invoked in two contexts:
+#   1. From the managing-skills 'add skill repo' procedure (one-time setup).
+#   2. From the auto-refresh hook on every run (opportunistic backport).
+#
+# Idempotent: copies only when the vendor copy is newer or content differs.
+# Refuses to overwrite an existing .skills/doctor.sh that does not look
+# like a doctor (header check), so user-authored files at that path
+# cannot be silently clobbered.
+#
+# Usage: bash install-doctor.sh [--quiet] [--help]
+set -euo pipefail
+
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    --quiet|-q) QUIET=1 ;;
+    --help|-h)
+      cat <<EOF
+Usage: bash <vendor>/managing-skills/scripts/install-doctor.sh [--quiet]
+
+Copies doctor.sh from the vendor location into <consumer-root>/.skills/doctor.sh.
+Idempotent — no-op if the destination already matches the source.
+
+Options:
+  --quiet, -q   Suppress 'installed' / 'updated' messages (errors still print).
+  --help, -h    Show this help and exit.
+
+Exit codes:
+  0  Success (installed, updated, or no-op).
+  1  Source doctor.sh not found, or destination is a non-doctor file.
+EOF
+      exit 0
+      ;;
+  esac
+done
+
+log() { [ "$QUIET" = "1" ] || echo "install-doctor: $*"; }
+err() { echo "install-doctor: $*" >&2; }
+
+# Source: doctor.sh lives next to this script.
+SRC="$(cd "$(dirname "$0")" && pwd)/doctor.sh"
+if [ ! -f "$SRC" ]; then
+  err "source doctor.sh not found at $SRC"
+  exit 1
+fi
+
+# Destination: consumer repo root. The consumer's repo root is whichever
+# directory contains skills-vendor/ — but since install-doctor.sh is invoked
+# from inside the consumer's checkout, the CWD is authoritative. Fall back
+# to git rev-parse for robustness when invoked from a subdirectory.
+DEST_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+DEST_DIR="$DEST_ROOT/.skills"
+DEST="$DEST_DIR/doctor.sh"
+
+mkdir -p "$DEST_DIR"
+
+# If destination exists and isn't recognizably a doctor, refuse to clobber.
+# The header check matches the marker line in doctor.sh.
+if [ -f "$DEST" ] && ! head -n 2 "$DEST" | grep -q '^# doctor.sh — diagnose and self-heal'; then
+  err "refusing to overwrite $DEST — file exists and is not a managing-skills doctor"
+  err "remove the file manually if you want to install the doctor"
+  exit 1
+fi
+
+# No-op if content already matches.
+if [ -f "$DEST" ] && cmp -s "$SRC" "$DEST"; then
+  log "no-op (already up to date)"
+  exit 0
+fi
+
+# Copy. Use install(1) when available for atomic mode-preserving copy.
+if command -v install >/dev/null 2>&1; then
+  install -m 755 "$SRC" "$DEST"
+else
+  cp "$SRC" "$DEST"
+  chmod 755 "$DEST"
+fi
+
+log "installed $DEST"
+exit 0

--- a/skills/managing-skills/scripts/install-doctor.sh
+++ b/skills/managing-skills/scripts/install-doctor.sh
@@ -63,8 +63,10 @@ DEST="$DEST_DIR/doctor.sh"
 mkdir -p "$DEST_DIR"
 
 # If destination exists and isn't recognizably a doctor, refuse to clobber.
-# The header check matches the marker line in doctor.sh.
-if [ -f "$DEST" ] && ! head -n 2 "$DEST" | grep -q '^# doctor.sh — diagnose and self-heal'; then
+# Grep for the stable marker comment that doctor.sh carries near the top of
+# the file (intentionally orthogonal to the wording of the doctor's intro
+# paragraph, which is allowed to change).
+if [ -f "$DEST" ] && ! head -n 3 "$DEST" | grep -q '^# managing-skills-doctor:'; then
   err "refusing to overwrite $DEST — file exists and is not a managing-skills doctor"
   err "remove the file manually if you want to install the doctor"
   exit 1
@@ -76,13 +78,8 @@ if [ -f "$DEST" ] && cmp -s "$SRC" "$DEST"; then
   exit 0
 fi
 
-# Copy. Use install(1) when available for atomic mode-preserving copy.
-if command -v install >/dev/null 2>&1; then
-  install -m 755 "$SRC" "$DEST"
-else
-  cp "$SRC" "$DEST"
-  chmod 755 "$DEST"
-fi
+# Copy via install(1) for atomic mode-preserving write.
+install -m 755 "$SRC" "$DEST"
 
 log "installed $DEST"
 exit 0

--- a/skills/managing-skills/scripts/skills-submodule-update.sh
+++ b/skills/managing-skills/scripts/skills-submodule-update.sh
@@ -49,6 +49,19 @@ LOG="$gitdir/skills-update.log"
 # Nothing to refresh if the project doesn't use the skills-vendor/ pattern.
 [ -d skills-vendor ] || exit 0
 
+# Opportunistically install/update .skills/doctor.sh — the backport path
+# for consumers added before doctor.sh existed. Runs on every session
+# (not gated by the once-per-day lock) so accidental deletions self-heal
+# at the next session start. install-doctor.sh is a no-op when content
+# matches, so the cost is one file compare per session.
+for installer in skills-vendor/*/skills/managing-skills/scripts/install-doctor.sh; do
+  [ -x "$installer" ] || continue
+  if ! bash "$installer" --quiet >>"$LOG" 2>&1; then
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] doctor install failed (see lines above)" >>"$LOG"
+  fi
+  break
+done
+
 # Lock check: once per UTC day. UTC matches the log timestamp timezone so
 # "today" never disagrees between lock and log at the day boundary.
 if [ -f "$LOCK" ] && [ "$(cat "$LOCK" 2>/dev/null || true)" = "$(date -u +%Y%m%d)" ]; then

--- a/skills/reviewing-architecture/SKILL.md
+++ b/skills/reviewing-architecture/SKILL.md
@@ -4,7 +4,7 @@ description: Performs a high-level architectural review evaluating structural he
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git.
 metadata:
   author: gregoryfoster
-  version: "1.1"
+  version: "1.2"
   triggers: AR, architecture review, architectural review
 ---
 
@@ -52,6 +52,7 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
+[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
 bash scripts/gather-context.sh
 ```
 

--- a/skills/reviewing-architecture/SKILL.md
+++ b/skills/reviewing-architecture/SKILL.md
@@ -52,9 +52,10 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
-[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
-bash scripts/gather-context.sh
+{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && bash scripts/gather-context.sh
 ```
+
+The leading group is a preflight: when `.skills/doctor.sh` is present, it heals any dangling vendor symlinks (or reports an actionable error); when absent, the group is a no-op. The `&&` chain skips `gather-context.sh` if the doctor reports unrecoverable state so the original "No such file or directory" noise doesn't drown out the doctor's message.
 
 Also:
 - Read AGENTS.md, README.md, and project layout documentation

--- a/skills/reviewing-code-php/SKILL.md
+++ b/skills/reviewing-code-php/SKILL.md
@@ -52,9 +52,10 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
-[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
-bash scripts/gather-context.sh
+{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && bash scripts/gather-context.sh
 ```
+
+The leading group is a preflight: when `.skills/doctor.sh` is present, it heals any dangling vendor symlinks (or reports an actionable error); when absent, the group is a no-op. The `&&` chain skips `gather-context.sh` if the doctor reports unrecoverable state so the original "No such file or directory" noise doesn't drown out the doctor's message.
 
 The script runs `composer validate --no-check-publish` at root and at every auto-discovered composer directory under `themes/` and `plugins/`, plus `php -l` on changed PHP files.
 

--- a/skills/reviewing-code-php/SKILL.md
+++ b/skills/reviewing-code-php/SKILL.md
@@ -4,7 +4,7 @@ description: "For PHP/WordPress projects (Bedrock + Sage 11): performs a structu
 compatibility: Designed for PHP 8.4 WordPress/Bedrock/Sage 11 monorepos with Composer. Requires git, gh, composer, php.
 metadata:
   author: gregoryfoster
-  version: "1.0"
+  version: "1.1"
   triggers: CR, code review, perform a review
 ---
 
@@ -52,6 +52,7 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
+[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
 bash scripts/gather-context.sh
 ```
 

--- a/skills/reviewing-code-python-click/SKILL.md
+++ b/skills/reviewing-code-python-click/SKILL.md
@@ -55,9 +55,10 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
-[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
-bash scripts/gather-context.sh
+{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && bash scripts/gather-context.sh
 ```
+
+The leading group is a preflight: when `.skills/doctor.sh` is present, it heals any dangling vendor symlinks (or reports an actionable error); when absent, the group is a no-op. The `&&` chain skips `gather-context.sh` if the doctor reports unrecoverable state so the original "No such file or directory" noise doesn't drown out the doctor's message.
 
 The script runs the variant's review-time checks informationally (output captured; failures become Phase 3 findings, not gather-context errors) alongside the standard git diff/status output:
 

--- a/skills/reviewing-code-python-click/SKILL.md
+++ b/skills/reviewing-code-python-click/SKILL.md
@@ -4,7 +4,7 @@ description: "For Python/Click CLI projects (uv + ruff + pytest + Pydantic v2): 
 compatibility: Designed for Python Click CLI projects using uv, ruff, pytest, and Pydantic v2. Requires git, gh, uv.
 metadata:
   author: gregoryfoster
-  version: "1.0"
+  version: "1.1"
   triggers: CR, code review, perform a review
 ---
 
@@ -55,6 +55,7 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
+[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
 bash scripts/gather-context.sh
 ```
 

--- a/skills/reviewing-code-python-fastapi/SKILL.md
+++ b/skills/reviewing-code-python-fastapi/SKILL.md
@@ -54,9 +54,10 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
-[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
-bash scripts/gather-context.sh
+{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && bash scripts/gather-context.sh
 ```
+
+The leading group is a preflight: when `.skills/doctor.sh` is present, it heals any dangling vendor symlinks (or reports an actionable error); when absent, the group is a no-op. The `&&` chain skips `gather-context.sh` if the doctor reports unrecoverable state so the original "No such file or directory" noise doesn't drown out the doctor's message.
 
 The script runs `uv run ruff check .` informationally (output captured; lint failures become Phase 3 findings, not gather-context errors) alongside the standard git diff/status output.
 

--- a/skills/reviewing-code-python-fastapi/SKILL.md
+++ b/skills/reviewing-code-python-fastapi/SKILL.md
@@ -4,7 +4,7 @@ description: "For Python/FastAPI projects (uv + ruff + pytest + Pydantic v2): pe
 compatibility: Designed for Python FastAPI projects using uv, ruff, pytest, Pydantic v2. Requires git, gh, uv.
 metadata:
   author: gregoryfoster
-  version: "1.0"
+  version: "1.1"
   triggers: CR, code review, perform a review
 ---
 
@@ -54,6 +54,7 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
+[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
 bash scripts/gather-context.sh
 ```
 

--- a/skills/reviewing-code/SKILL.md
+++ b/skills/reviewing-code/SKILL.md
@@ -52,9 +52,10 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
-[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
-bash scripts/gather-context.sh
+{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && bash scripts/gather-context.sh
 ```
+
+The leading group is a preflight: when `.skills/doctor.sh` is present, it heals any dangling vendor symlinks (or reports an actionable error); when absent, the group is a no-op. The `&&` chain skips `gather-context.sh` if the doctor reports unrecoverable state so the original "No such file or directory" noise doesn't drown out the doctor's message.
 
 Also:
 - Read AGENTS.md conventions relevant to changed files

--- a/skills/reviewing-code/SKILL.md
+++ b/skills/reviewing-code/SKILL.md
@@ -4,7 +4,7 @@ description: Performs a structured code and documentation review using a severit
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git and gh CLI.
 metadata:
   author: gregoryfoster
-  version: "1.4"
+  version: "1.5"
   triggers: CR, code review, perform a review
 ---
 
@@ -52,6 +52,7 @@ Determine what to review (priority order):
 ### Phase 1 — Gather context
 
 ```bash
+[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
 bash scripts/gather-context.sh
 ```
 

--- a/skills/shipping-work-php/SKILL.md
+++ b/skills/shipping-work-php/SKILL.md
@@ -4,7 +4,7 @@ description: "For PHP/WordPress projects (Bedrock + Sage 11): finalizes work by 
 compatibility: Designed for PHP 8.4 WordPress/Bedrock/Sage 11 monorepos with Composer. Requires git, gh, composer, php.
 metadata:
   author: gregoryfoster
-  version: "1.0"
+  version: "1.1"
   triggers: ship it, push GH, close GH, wrap up
 ---
 
@@ -45,6 +45,7 @@ Determine which GitHub issue(s) to close (priority order):
 ### Step 1 — Run pre-ship checks
 
 ```bash
+[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
 bash scripts/pre-ship.sh
 ```
 

--- a/skills/shipping-work-php/SKILL.md
+++ b/skills/shipping-work-php/SKILL.md
@@ -45,9 +45,10 @@ Determine which GitHub issue(s) to close (priority order):
 ### Step 1 — Run pre-ship checks
 
 ```bash
-[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
-bash scripts/pre-ship.sh
+{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && bash scripts/pre-ship.sh
 ```
+
+The leading group is a preflight: when `.skills/doctor.sh` is present, it heals any dangling vendor symlinks (or reports an actionable error); when absent, the group is a no-op. The `&&` chain skips `pre-ship.sh` if the doctor reports unrecoverable state so the original "No such file or directory" noise doesn't drown out the doctor's message.
 
 > Lint runs 4 parallel `php -l` workers by default; tune via `PRE_SHIP_PHP_LINT_JOBS=N bash scripts/pre-ship.sh` for very large monorepos.
 

--- a/skills/shipping-work-python-click/SKILL.md
+++ b/skills/shipping-work-python-click/SKILL.md
@@ -46,9 +46,10 @@ Determine which GitHub issue(s) to close (priority order):
 ### Step 1 — Run pre-ship checks
 
 ```bash
-[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
-bash scripts/pre-ship.sh
+{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && bash scripts/pre-ship.sh
 ```
+
+The leading group is a preflight: when `.skills/doctor.sh` is present, it heals any dangling vendor symlinks (or reports an actionable error); when absent, the group is a no-op. The `&&` chain skips `pre-ship.sh` if the doctor reports unrecoverable state so the original "No such file or directory" noise doesn't drown out the doctor's message.
 
 ```
 NO CONTINUATION IF CHECKS FAIL

--- a/skills/shipping-work-python-click/SKILL.md
+++ b/skills/shipping-work-python-click/SKILL.md
@@ -4,7 +4,7 @@ description: "For Python/Click CLI projects (uv + ruff + pytest): finalizes work
 compatibility: Designed for Python Click CLI projects using uv, ruff, pytest. Requires git, gh, uv.
 metadata:
   author: gregoryfoster
-  version: "1.0"
+  version: "1.1"
   triggers: ship it, push GH, close GH, wrap up
 ---
 
@@ -46,6 +46,7 @@ Determine which GitHub issue(s) to close (priority order):
 ### Step 1 — Run pre-ship checks
 
 ```bash
+[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
 bash scripts/pre-ship.sh
 ```
 

--- a/skills/shipping-work-python-fastapi/SKILL.md
+++ b/skills/shipping-work-python-fastapi/SKILL.md
@@ -4,7 +4,7 @@ description: "For Python/FastAPI projects (uv + ruff + pytest): finalizes work b
 compatibility: Designed for Python FastAPI projects using uv, ruff, pytest. Requires git, gh, uv. pytest-cov is optional — pre-ship.sh auto-detects it and adds --no-cov when present.
 metadata:
   author: gregoryfoster
-  version: "1.2"
+  version: "1.3"
   triggers: ship it, push GH, close GH, wrap up
 ---
 
@@ -45,6 +45,7 @@ Determine which GitHub issue(s) to close (priority order):
 ### Step 1 — Run pre-ship checks
 
 ```bash
+[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
 bash scripts/pre-ship.sh
 ```
 

--- a/skills/shipping-work-python-fastapi/SKILL.md
+++ b/skills/shipping-work-python-fastapi/SKILL.md
@@ -45,9 +45,10 @@ Determine which GitHub issue(s) to close (priority order):
 ### Step 1 — Run pre-ship checks
 
 ```bash
-[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
-bash scripts/pre-ship.sh
+{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && bash scripts/pre-ship.sh
 ```
+
+The leading group is a preflight: when `.skills/doctor.sh` is present, it heals any dangling vendor symlinks (or reports an actionable error); when absent, the group is a no-op. The `&&` chain skips `pre-ship.sh` if the doctor reports unrecoverable state so the original "No such file or directory" noise doesn't drown out the doctor's message.
 
 ```
 NO CONTINUATION IF CHECKS FAIL

--- a/skills/shipping-work/SKILL.md
+++ b/skills/shipping-work/SKILL.md
@@ -45,9 +45,10 @@ Determine which GitHub issue(s) to close (priority order):
 ### Step 1 — Run pre-ship checks
 
 ```bash
-[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
-bash scripts/pre-ship.sh
+{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && bash scripts/pre-ship.sh
 ```
+
+The leading group is a preflight: when `.skills/doctor.sh` is present, it heals any dangling vendor symlinks (or reports an actionable error); when absent, the group is a no-op. The `&&` chain skips `pre-ship.sh` if the doctor reports unrecoverable state so the original "No such file or directory" noise doesn't drown out the doctor's message.
 
 ```
 NO CONTINUATION IF CHECKS FAIL

--- a/skills/shipping-work/SKILL.md
+++ b/skills/shipping-work/SKILL.md
@@ -4,7 +4,7 @@ description: "Finalizes work by ensuring everything is committed, pushed to the 
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git and gh CLI.
 metadata:
   author: gregoryfoster
-  version: "1.2"
+  version: "1.3"
   triggers: ship it, push GH, close GH, wrap up
 ---
 
@@ -45,6 +45,7 @@ Determine which GitHub issue(s) to close (priority order):
 ### Step 1 — Run pre-ship checks
 
 ```bash
+[ -x .skills/doctor.sh ] && bash .skills/doctor.sh   # heals dangling vendor symlinks; silent if absent
 bash scripts/pre-ship.sh
 ```
 

--- a/tests/structural/test_content_invariants.py
+++ b/tests/structural/test_content_invariants.py
@@ -1197,3 +1197,80 @@ class TestVariantFamilyConsistency:
             "true, not which tool — variant-specific tooling lives in gather-context.sh "
             "and pre-ship.sh, not the law."
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 doctor preflight (drift assertion)
+# ---------------------------------------------------------------------------
+
+
+# Each tuple is (skill-name, phase-1-script-name). Reviewing-* skills use
+# gather-context.sh; shipping-* skills use pre-ship.sh.
+SKILLS_REQUIRING_DOCTOR_PREFLIGHT = [
+    ("reviewing-code", "gather-context.sh"),
+    ("reviewing-code-php", "gather-context.sh"),
+    ("reviewing-code-python-click", "gather-context.sh"),
+    ("reviewing-code-python-fastapi", "gather-context.sh"),
+    ("reviewing-architecture", "gather-context.sh"),
+    ("shipping-work", "pre-ship.sh"),
+    ("shipping-work-php", "pre-ship.sh"),
+    ("shipping-work-python-click", "pre-ship.sh"),
+    ("shipping-work-python-fastapi", "pre-ship.sh"),
+]
+
+
+class TestPhase1DoctorPreflight:
+    """Every reviewing-*/shipping-* SKILL.md must invoke `.skills/doctor.sh`
+    as a guarded preflight before the gather/pre-ship script, chained with
+    `&&` so the original "No such file or directory" noise from a dangling
+    vendor symlink chain doesn't drown out the doctor's actionable error.
+    The chain is followed by a paragraph explaining the semantics so a
+    future reader doesn't have to reverse-engineer the dense one-liner.
+
+    A future SKILL.md refactor could drop the chain or the paragraph from
+    one variant and the inconsistency would only surface in a broken-symlink
+    scenario (fresh `git worktree add`, shallow CI clone). These tests pin
+    both so the inconsistency surfaces during review instead.
+    """
+
+    @pytest.fixture(
+        params=SKILLS_REQUIRING_DOCTOR_PREFLIGHT,
+        ids=lambda p: p[0],
+    )
+    def skill_and_script(self, request):
+        skill_name, script_name = request.param
+        return skill(skill_name).body, script_name
+
+    def test_doctor_preflight_chain_present(self, skill_and_script):
+        body, script_name = skill_and_script
+        # Match the canonical chain form including the phase-1 script name.
+        # The `&&` is the load-bearing part: it skips gather/pre-ship when
+        # the doctor reports unrecoverable state.
+        expected = (
+            "{ [ ! -x .skills/doctor.sh ] || bash .skills/doctor.sh; } && "
+            f"bash scripts/{script_name}"
+        )
+        assert expected in body, (
+            f"SKILL.md Phase 1 must invoke the doctor preflight as:\n  {expected}\n"
+            "See skills/managing-skills/scripts/doctor.sh and "
+            "https://github.com/gregoryfoster/skills/issues/46."
+        )
+
+    def test_doctor_preflight_paragraph_present(self, skill_and_script):
+        body, script_name = skill_and_script
+        # Pin the explanatory paragraph that follows the chain — same wording
+        # across the family with only the phase-1 script name varying.
+        expected = (
+            "The leading group is a preflight: when `.skills/doctor.sh` is "
+            "present, it heals any dangling vendor symlinks (or reports an "
+            "actionable error); when absent, the group is a no-op. The `&&` "
+            f"chain skips `{script_name}` if the doctor reports unrecoverable "
+            "state so the original \"No such file or directory\" noise "
+            "doesn't drown out the doctor's message."
+        )
+        assert expected in body, (
+            "SKILL.md Phase 1 must include the explanatory paragraph below "
+            "the doctor preflight chain so future readers don't have to "
+            "reverse-engineer the dense one-liner. Expected:\n\n  "
+            + expected
+        )


### PR DESCRIPTION
## Summary

- Adds `.skills/doctor.sh` — a real (non-symlinked) preflight script installed into consumer repos that walks `skills/*` symlinks, auto-runs `git submodule update --init --recursive` when any dangle, and prints actionable errors otherwise.
- Extends the once-per-day auto-refresh hook to opportunistically install/update the doctor on every session start — the backport path so existing consumers (cannabis.observer-wordpress et al.) pick it up automatically.
- Updates Phase 1 of every `reviewing-*` / `shipping-*` SKILL.md to invoke the doctor as a guarded preflight (`[ -x .skills/doctor.sh ] && bash .skills/doctor.sh`), so consumers without the doctor see no behavior change.

Closes #46. Plan: [docs/plans/2026-05-25-dangling-skill-symlinks-doctor.md](docs/plans/2026-05-25-dangling-skill-symlinks-doctor.md).

## Why not the issue's Approach A?

Approach A (per-skill wrapper at the symlink target) was rejected because the wrapper would itself sit inside the symlinked skill directory — and therefore be just as unreachable as `gather-context.sh` in the exact failure mode it's meant to repair. The doctor lives at `.skills/doctor.sh` (a real file at the consumer side) precisely so it remains reachable when the vendor chain is broken.

## Test plan

- [x] Smoke-tested `doctor.sh`: healthy state silent, broken symlink detected and reported with actionable error, `--check-only` / `--verbose` / `--version` / unknown-flag handling
- [x] Smoke-tested `install-doctor.sh`: fresh install, re-run no-op, clobber guard against user-authored file at target path
- [x] End-to-end simulated a consumer layout (vendor + symlink chain + doctor install + chain break) and confirmed the doctor reports the unreachable symlink
- [ ] Verify against a real `git worktree add` of a downstream consumer (cannabis.observer-wordpress) — pending merge + submodule pointer bump on that side
- [ ] Verify the auto-refresh hook installs the doctor on session start for an existing consumer that doesn't have it yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)
