### PR TITLE
#50 doctor.sh: classify SSH/HTTPS auth failures + pre-flight ping

### DIFF
--- a/skills/managing-skills/SKILL.md
+++ b/skills/managing-skills/SKILL.md
@@ -4,7 +4,7 @@ description: "Manages external skill repos in a project using the git submodule 
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git CLI.
 metadata:
   author: gregoryfoster
-  version: "1.4"
+  version: "1.5"
   triggers: add skill repo, add external skills, manage skills, update vendor skills, install skills hook, enable auto-refresh
 ---
 
@@ -289,6 +289,37 @@ Or clone with submodules in one step:
 ```bash
 git clone --recurse-submodules <project-url>
 ```
+
+## Troubleshooting
+
+### `doctor.sh` reports an SSH/HTTPS auth failure
+
+When the doctor runs `git submodule update --init --recursive` and the underlying clone can't authenticate, it prints a targeted remediation block instead of the generic "submodule update failed" line. A second path — the SSH pre-flight ping — surfaces the same block before submodule init when `.gitmodules` references SSH remotes (`git@<host>:…` or `ssh://git@<host>/…`) and the agent isn't reachable from the shell that invoked the doctor.
+
+The doctor distinguishes two failure modes; the remediation differs by mode.
+
+#### For auth failures (`Permission denied (…)` / `Authentication failed for 'https://…'`)
+
+Walk the rungs top-down — most reports trace to one of the first three:
+
+1. **Agent not reachable.** `ssh-add -l` returns "Error connecting to authentication agent" → start the agent and re-add keys. On macOS this usually happens after a reboot or a fresh shell session.
+2. **Agent reachable but empty.** `ssh-add --apple-use-keychain ~/.ssh/id_ed25519` once, then add a `Host github.com` block to `~/.ssh/config` with `AddKeysToAgent yes` and `UseKeychain yes` so the key auto-loads on every shell.
+3. **Agent works interactively but not from a wrapper script.** A `dev.sh` (or similar) in the call chain is scrubbing `SSH_AUTH_SOCK`. Test from the same shell with `ssh -T git@github.com`: if it works there but the wrapper's subshell fails, the fix lives in the wrapper.
+4. **Public submodule, no credentials needed.** The global HTTPS rewrite (`git config --global url."https://github.com/".insteadOf "git@github.com:"`) lets git clone without auth — note it affects every repo on that machine. **In CI, ephemeral containers, or any non-interactive runner**, prefer the runner's native credential mechanism (deploy key, `GITHUB_TOKEN`, app token) over the global rewrite — those are scoped to the run and don't bleed across repos.
+
+#### For host-key failures (`Host key verification failed`)
+
+The pre-flight runs `ssh -T` with `StrictHostKeyChecking=yes` so unknown hosts are rejected loudly instead of silently appended to your `known_hosts`. The doctor prints a separate, smaller block pointing at `ssh-keyscan`:
+
+```bash
+ssh-keyscan github.com >> ~/.ssh/known_hosts
+```
+
+Verify the forge's [published fingerprints](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints) against the `ssh-keyscan` output **before** appending — `ssh-keyscan` will happily echo whatever a man-in-the-middle answers.
+
+#### Skipping the pre-flight
+
+Pass `--no-preflight` to skip the SSH ping if the operator already knows the agent state and wants to skip the 3-second `ConnectTimeout` per invocation. The submodule-init classification still runs after a failure either way.
 
 ## Notes
 

--- a/skills/managing-skills/scripts/doctor.sh
+++ b/skills/managing-skills/scripts/doctor.sh
@@ -21,21 +21,23 @@
 #   bash .skills/doctor.sh
 #   bash scripts/gather-context.sh
 #
-# Usage: bash .skills/doctor.sh [--check-only] [--verbose] [--help]
+# Usage: bash .skills/doctor.sh [--check-only] [--verbose] [--no-preflight] [--help]
 set -euo pipefail
 
-VERSION="2026-05-26-2"
+VERSION="2026-05-28-6"
 
 CHECK_ONLY=0
 VERBOSE=0
+NO_PREFLIGHT=0
 for arg in "$@"; do
   case "$arg" in
     --check-only) CHECK_ONLY=1 ;;
     --verbose|-v) VERBOSE=1 ;;
+    --no-preflight) NO_PREFLIGHT=1 ;;
     --version) echo "$VERSION"; exit 0 ;;
     --help|-h)
       cat <<EOF
-Usage: bash .skills/doctor.sh [--check-only] [--verbose]
+Usage: bash .skills/doctor.sh [--check-only] [--verbose] [--no-preflight]
 
 Diagnose and self-heal dangling skill symlinks in skills/.
 
@@ -44,17 +46,29 @@ present, runs 'git submodule update --init --recursive' and re-checks.
 Exits 0 silently when healthy. Exits non-zero with an actionable error
 when self-healing fails or is not possible (e.g. no .git directory).
 
+When submodule init fails with a well-known SSH/HTTPS auth signature
+(Permission denied, Could not read from remote repository, Authentication
+failed for 'https://'), a targeted remediation block is printed instead
+of the generic 'submodule update failed' line. The same block is printed
+by the pre-flight SSH check when .gitmodules references SSH remotes and
+the agent isn't reachable from this shell. A separate remediation block
+covers host-key-verification failures (ssh-keyscan-based fix).
+
 Options:
   --check-only    Report broken symlinks but do not run submodule init
                   (overridden by the archive-checkout path when .git is
                   absent — the archive case prints its own diagnosis).
+  --no-preflight  Skip the SSH pre-flight ping. Useful when the operator
+                  knows the agent state and doesn't want the 3-second
+                  ConnectTimeout on every invocation.
   --verbose, -v   Print resolution details even when healthy.
   --version       Print script version and exit.
   --help, -h      Show this help and exit.
 
 Exit codes:
   0  All skill symlinks resolve (or skills/ does not exist).
-  1  One or more symlinks remain broken after self-heal attempt.
+  1  One or more symlinks remain broken after self-heal attempt, or
+     pre-flight SSH check failed.
   2  Invalid invocation (e.g. unknown flag).
 EOF
       exit 0
@@ -127,9 +141,191 @@ if [ "$CHECK_ONLY" = "1" ]; then
   exit 1
 fi
 
+# Targeted remediation printed when an auth failure is detected — either by
+# the pre-flight ping below or by classifying submodule init's stderr.
+# Kept generic across hosts (github.com is the dominant case but we don't
+# hard-code it in the message) and explicit about each layer the user
+# might need to fix: agent reachable, key loaded, agent visible to
+# subprocesses, fallback to HTTPS.
+print_ssh_remediation() {
+  cat >&2 <<'EOF'
+
+doctor: the auth check above failed — auth to one of the submodule
+remotes was refused. Common causes (and fixes):
+
+  1. SSH agent not reachable from this shell.
+       ssh-add -l
+     "Error connecting to authentication agent" → start the agent and
+     re-add keys.
+
+  2. Agent has no identities loaded.
+     Add the default key (macOS keychain integration):
+       ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+     (adjust the key path if yours isn't id_ed25519 — `ls ~/.ssh/id_*`
+     shows what's available.)
+     And persist via ~/.ssh/config so the key auto-loads:
+       Host github.com
+         AddKeysToAgent yes
+         UseKeychain yes
+         IdentityFile ~/.ssh/id_ed25519
+
+  3. Auth works in your terminal but not from a wrapper script.
+       ssh -T git@github.com
+     If that succeeds interactively but fails here, a wrapper in the
+     chain (e.g. dev.sh) is scrubbing SSH_AUTH_SOCK from the env.
+
+  4. Public submodule, no SSH credentials available.
+     Force HTTPS for github.com globally (affects ALL repos on this
+     machine — use only if you understand the scope):
+       git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+EOF
+}
+
+# Companion remediation for the host-key-verification failure path. Surfaced
+# when the pre-flight ping under StrictHostKeyChecking=yes is rejected
+# because the remote's host key isn't in ~/.ssh/known_hosts. The agent
+# remediation above doesn't apply here — the operator just needs to trust
+# the host key.
+print_host_key_remediation() {
+  cat >&2 <<'EOF'
+
+doctor: SSH refused to talk to one of the submodule remotes because its
+host key isn't in ~/.ssh/known_hosts. Trust the host key (verify the
+fingerprint against the forge's published list first):
+
+  ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+GitHub publishes its current host-key fingerprints at
+https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints —
+compare the ssh-keyscan output before appending. For other forges, check
+their docs for the equivalent.
+
+EOF
+}
+
+# Pre-flight: when .gitmodules references SSH remotes, verify SSH auth to
+# each referenced host before attempting submodule init. Catches the
+# common "agent not reachable / key not loaded" case with a clean
+# message instead of letting submodule init produce a wall of clone
+# errors. Skipped when .gitmodules is HTTPS-only or absent, and skippable
+# entirely with --no-preflight.
+preflight_ssh_check() {
+  [ "$NO_PREFLIGHT" = "1" ] && return 0
+  [ -f .gitmodules ] || return 0
+
+  # Extract unique host names from SSH-style submodule URLs:
+  #   url = git@<host>:<path>
+  #   url = ssh://git@<host>[:<port>]/<path>
+  local hosts
+  hosts="$(awk '
+    /^[[:space:]]*url[[:space:]]*=[[:space:]]*git@/ {
+      # url = git@host:path → split on @ and :
+      sub(/^[^@]*@/, "", $0); sub(/:.*$/, "", $0); print
+    }
+    /^[[:space:]]*url[[:space:]]*=[[:space:]]*ssh:\/\/git@/ {
+      # url = ssh://git@host[:port]/path → strip scheme+user, then host
+      sub(/^.*@/, "", $0); sub(/[:\/].*$/, "", $0); print
+    }
+  ' .gitmodules | sort -u)"
+  [ -n "$hosts" ] || return 0
+
+  local host out failed=0
+  local -a auth_failed=()
+  local -a hostkey_failed=()
+  for host in $hosts; do
+    # GitHub (and most forges) return exit 1 even on successful auth
+    # because there's no shell to allocate ("PTY allocation request
+    # failed" / "successfully authenticated"). The reliable signal is in
+    # the output, not the exit code. Two failure modes worth
+    # distinguishing:
+    #
+    #   - "Permission denied (...)" — auth refused. The parenthesized
+    #     methods vary by server config (publickey / password /
+    #     publickey,password,keyboard-interactive / etc.), so we match
+    #     on the open-paren form to catch all variants without false-
+    #     positiving on banners that happen to contain the literal
+    #     string "Permission denied".
+    #   - "Host key verification failed" — server's host key isn't in
+    #     known_hosts. We run with StrictHostKeyChecking=yes
+    #     deliberately: the alternative (accept-new) silently expands
+    #     the operator's known_hosts on first contact, which is a
+    #     security choice this script shouldn't make on the operator's
+    #     behalf. BatchMode=yes prevents the script from hanging on the
+    #     interactive trust prompt.
+    #
+    # Other failures (DNS, timeout, network) are not classified — we
+    # don't want false positives that block valid retries on flaky
+    # network conditions.
+    out="$(ssh -T -o BatchMode=yes -o ConnectTimeout=3 \
+              -o StrictHostKeyChecking=yes "git@${host}" 2>&1 || true)"
+    if printf '%s\n' "$out" | grep -qE "Permission denied \("; then
+      auth_failed+=("$host")
+      failed=1
+    elif printf '%s\n' "$out" | grep -qi "Host key verification failed"; then
+      hostkey_failed+=("$host")
+      failed=1
+    fi
+  done
+
+  if [ "$failed" -eq 1 ]; then
+    if [ "${#auth_failed[@]}" -gt 0 ]; then
+      echo "doctor: SSH pre-flight failed — agent cannot authenticate to: ${auth_failed[*]}" >&2
+      print_ssh_remediation
+    fi
+    if [ "${#hostkey_failed[@]}" -gt 0 ]; then
+      echo "doctor: SSH pre-flight failed — host key not trusted for: ${hostkey_failed[*]}" >&2
+      print_host_key_remediation
+    fi
+    return 1
+  fi
+  return 0
+}
+
+if ! preflight_ssh_check; then
+  exit 1
+fi
+
 echo "doctor: dangling skill symlinks detected — initializing submodules..." >&2
-if ! git submodule update --init --recursive >&2; then
-  echo "doctor: 'git submodule update --init --recursive' failed" >&2
+
+# Capture stderr for post-hoc classification while also streaming it live
+# so the user sees git's output during slow clones. We use a named pipe
+# (fifo) + explicit-backgrounded tee with a known PID instead of the
+# more compact `2> >(tee … >&2)` process-substitution form: bash 3.2
+# (the default on macOS without Homebrew) does not track process
+# substitutions in the jobs table, so `wait` can't reliably reap the
+# tee, leaving a microsecond-wide race between tee's final flush and
+# our grep. A real backgrounded job with `wait "$TEE_PID"` works on
+# every bash from 3.2 onward. Both temp paths live inside a single
+# mktemp -d directory so the trap can `rm -rf` once.
+SUBMODULE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/doctor-submodule.XXXXXX")"
+# Install the cleanup trap before any further setup that could fail (mkfifo,
+# tee &) so a partial-init failure still removes the tempdir.
+trap 'rm -rf "$SUBMODULE_TMP"' EXIT
+SUBMODULE_FIFO="$SUBMODULE_TMP/stderr"
+SUBMODULE_ERR="$SUBMODULE_TMP/captured"
+mkfifo "$SUBMODULE_FIFO"
+
+tee "$SUBMODULE_ERR" < "$SUBMODULE_FIFO" >&2 &
+TEE_PID=$!
+
+RC=0
+# When git exits, the fifo write side closes; tee reads EOF and exits.
+git submodule update --init --recursive 2>"$SUBMODULE_FIFO" || RC=$?
+# `|| true` so a non-zero tee exit (e.g., write error) doesn't trip set -e.
+wait "$TEE_PID" || true
+
+if [ "$RC" -ne 0 ]; then
+  # Match the open-paren form of SSH auth refusal so we catch every
+  # variant (publickey / password / publickey,password,keyboard-interactive
+  # / ...). HTTPS auth has its own signature unrelated to SSH; "Could not
+  # read from remote repository" appears for both SSH and HTTPS clone
+  # failures rooted in auth.
+  if grep -qE "Permission denied \(|Could not read from remote repository|Authentication failed for 'https://" "$SUBMODULE_ERR"; then
+    print_ssh_remediation
+  else
+    echo "doctor: 'git submodule update --init --recursive' failed" >&2
+  fi
   exit 1
 fi
 

--- a/tests/structural/test_doctor_ssh_remediation.py
+++ b/tests/structural/test_doctor_ssh_remediation.py
@@ -1,0 +1,461 @@
+"""Behavioral tests for doctor.sh SSH/HTTPS auth remediation (issue #50).
+
+Exercises the script end-to-end against a throwaway git repo with a
+dangling skill symlink so the submodule-init code path actually runs.
+Fake `git` and `ssh` shims on PATH let us control the failure signal
+without making real network calls.
+
+Coverage:
+- submodule init fails with each of three classified auth signatures
+  → targeted remediation block printed
+- submodule init fails with a generic (non-auth) error → generic
+  message only (no false-positive remediation)
+- SSH pre-flight short-circuits before submodule init when .gitmodules
+  references SSH remotes and ssh -T reports Permission denied
+- HTTPS-only .gitmodules → pre-flight is a no-op (no ssh invocation)
+- --no-preflight skips the SSH ping even when .gitmodules is SSH
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parent.parent.parent
+    / "skills"
+    / "managing-skills"
+    / "scripts"
+    / "doctor.sh"
+)
+
+
+def _clean_env() -> dict:
+    """Env without inherited GIT_* vars — same precaution as
+    test_worktree_destroy_base. Pre-commit and other tooling can set
+    GIT_INDEX_FILE etc., which would leak into `git -C <tmp_repo>` calls
+    inside the script and confuse them."""
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _real_git() -> str:
+    return shutil.which("git") or "/usr/bin/git"
+
+
+def _make_git_shim(bin_dir: Path, stderr_body: str, exit_code: int = 1) -> None:
+    """Create a fake `git` on PATH that intercepts `git submodule …` with a
+    canned stderr + exit code, and delegates every other invocation to the
+    real git so `rev-parse --show-toplevel` and friends still work.
+
+    Hand-rolled (no textwrap.dedent) because the heredoc terminator must
+    sit at column 0 — dedent uses the common leading whitespace of all
+    lines, which collapses to zero when stderr_body is unindented and
+    leaves the surrounding shim lines indented, breaking heredoc parsing.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    real = _real_git()
+    shim = bin_dir / "git"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "submodule" ]; then\n'
+        "  cat >&2 <<'__SHIM_STDERR__'\n"
+        f"{stderr_body}\n"
+        "__SHIM_STDERR__\n"
+        f"  exit {exit_code}\n"
+        "fi\n"
+        f'exec {real} "$@"\n'
+    )
+    shim.chmod(0o755)
+
+
+def _make_ssh_shim(bin_dir: Path, stderr_body: str, exit_code: int = 255) -> None:
+    """Create a fake `ssh` on PATH used by the pre-flight ping. GitHub-style
+    `ssh -T` returns exit 1 on success and 255 on connection failure; we
+    only care about whether stderr contains 'Permission denied'."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "ssh"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        "cat >&2 <<'__SHIM_STDERR__'\n"
+        f"{stderr_body}\n"
+        "__SHIM_STDERR__\n"
+        f"exit {exit_code}\n"
+    )
+    shim.chmod(0o755)
+
+
+def _make_ssh_shim_per_host(
+    bin_dir: Path, host_responses: dict[str, tuple[str, int]]
+) -> None:
+    """Per-host dispatch ssh shim. `host_responses` maps the host part of
+    `git@<host>` to `(stderr_body, exit_code)`. Uses a POSIX `case`
+    statement (not bash `[[`) for portability with the doctor's
+    bash-3.2-supported invocation.
+
+    Unmatched ssh invocations exit 99 with a stderr message naming the
+    args — useful when a test fails because the doctor's ssh args drifted
+    from what the shim expects; check `result.stderr` for the unmatched
+    `git@<host>` and update `host_responses` to cover it.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    arms = []
+    for host, (stderr_body, exit_code) in host_responses.items():
+        arms.append(
+            f'  *" git@{host} "*)\n'
+            "    cat >&2 <<'__SHIM_STDERR__'\n"
+            f"{stderr_body}\n"
+            "__SHIM_STDERR__\n"
+            f"    exit {exit_code}\n"
+            "    ;;\n"
+        )
+    body = (
+        "#!/usr/bin/env bash\n"
+        'case " $* " in\n'
+        + "".join(arms)
+        + "  *)\n"
+        '    echo "ssh-shim: unmatched args: $*" >&2\n'
+        "    exit 99\n"
+        "    ;;\n"
+        "esac\n"
+    )
+    shim = bin_dir / "ssh"
+    shim.write_text(body)
+    shim.chmod(0o755)
+
+
+@pytest.fixture
+def tmp_repo(tmp_path: Path) -> Path:
+    """Repo with a dangling skills/foo symlink so scan_broken populates and
+    the script reaches the submodule-init / pre-flight code paths."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "-b", "main"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=_clean_env(),
+    )
+    skills = repo / "skills"
+    skills.mkdir()
+    # Symlink whose target doesn't exist — triggers the doctor's broken-link path.
+    os.symlink("../skills-vendor/nonexistent/skills/foo", skills / "foo")
+    return repo
+
+
+def _run_doctor(
+    repo: Path,
+    extra_path: Path | None = None,
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess:
+    env = _clean_env()
+    if extra_path is not None:
+        # Prepend shim dir so our shims win over /usr/bin/{git,ssh}.
+        env["PATH"] = f"{extra_path}:{env.get('PATH', '/usr/bin:/bin')}"
+    args = ["bash", str(SCRIPT), *(extra_args or [])]
+    return subprocess.run(args, capture_output=True, text=True, cwd=repo, env=env)
+
+
+# ---------------------------------------------------------------------------
+# Submodule-init stderr classification
+# ---------------------------------------------------------------------------
+
+
+class TestSubmoduleInitClassification:
+    """When submodule init fails with a recognized auth signature, the doctor
+    prints the targeted remediation block instead of the generic line."""
+
+    def test_publickey_denied_triggers_remediation(self, tmp_repo, tmp_path):
+        _make_git_shim(
+            tmp_path / "bin",
+            "Cloning into '/tmp/x'...\n"
+            "git@github.com: Permission denied (publickey).\n"
+            "fatal: Could not read from remote repository.\n"
+            "Please make sure you have the correct access rights\n"
+            "and the repository exists.",
+        )
+        # --no-preflight so the SSH ping path doesn't intercept first.
+        result = _run_doctor(
+            tmp_repo, extra_path=tmp_path / "bin", extra_args=["--no-preflight"]
+        )
+        assert result.returncode == 1, result.stderr
+        # Remediation markers — keep loose so wording tweaks don't break the test.
+        assert "ssh-add -l" in result.stderr
+        assert "apple-use-keychain" in result.stderr
+        assert "insteadOf" in result.stderr
+        # Original git stderr is still mirrored back so the user sees the raw signal.
+        assert "Permission denied (publickey)" in result.stderr
+
+    def test_could_not_read_from_remote_triggers_remediation(self, tmp_repo, tmp_path):
+        _make_git_shim(
+            tmp_path / "bin",
+            "fatal: Could not read from remote repository.\n"
+            "Please make sure you have the correct access rights.",
+        )
+        result = _run_doctor(
+            tmp_repo, extra_path=tmp_path / "bin", extra_args=["--no-preflight"]
+        )
+        assert result.returncode == 1
+        assert "apple-use-keychain" in result.stderr
+
+    def test_https_authentication_failed_triggers_remediation(self, tmp_repo, tmp_path):
+        _make_git_shim(
+            tmp_path / "bin",
+            "fatal: Authentication failed for 'https://github.com/example/foo.git/'",
+        )
+        result = _run_doctor(
+            tmp_repo, extra_path=tmp_path / "bin", extra_args=["--no-preflight"]
+        )
+        assert result.returncode == 1
+        assert "apple-use-keychain" in result.stderr
+
+    def test_password_denied_triggers_remediation(self, tmp_repo, tmp_path):
+        """The tightened `Permission denied \\(` regex must catch the
+        password-method variant, not just publickey."""
+        _make_git_shim(
+            tmp_path / "bin",
+            "git@example.com: Permission denied (password).\n"
+            "fatal: Could not read from remote repository.",
+        )
+        result = _run_doctor(
+            tmp_repo, extra_path=tmp_path / "bin", extra_args=["--no-preflight"]
+        )
+        assert result.returncode == 1
+        assert "apple-use-keychain" in result.stderr
+
+    def test_multi_method_denied_triggers_remediation(self, tmp_repo, tmp_path):
+        """Servers with multiple auth methods enabled return a comma-joined
+        list inside the parentheses — the open-paren regex still catches it."""
+        _make_git_shim(
+            tmp_path / "bin",
+            "git@example.com: Permission denied (publickey,password,keyboard-interactive).\n"
+            "fatal: Could not read from remote repository.",
+        )
+        result = _run_doctor(
+            tmp_repo, extra_path=tmp_path / "bin", extra_args=["--no-preflight"]
+        )
+        assert result.returncode == 1
+        assert "apple-use-keychain" in result.stderr
+
+    def test_generic_failure_no_false_positive_remediation(self, tmp_repo, tmp_path):
+        """A non-auth submodule failure must not trigger the SSH remediation
+        block — only the original generic line. Protects against the
+        classifier matching too broadly and confusing the operator."""
+        _make_git_shim(
+            tmp_path / "bin",
+            "fatal: destination path '/tmp/x' already exists and is not empty",
+        )
+        result = _run_doctor(
+            tmp_repo, extra_path=tmp_path / "bin", extra_args=["--no-preflight"]
+        )
+        assert result.returncode == 1
+        assert "'git submodule update --init --recursive' failed" in result.stderr
+        assert "apple-use-keychain" not in result.stderr
+        assert "ssh-add -l" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# SSH pre-flight ping
+# ---------------------------------------------------------------------------
+
+
+class TestSSHPreflight:
+    """The pre-flight runs only when .gitmodules references SSH remotes.
+    A 'Permission denied' result short-circuits before submodule init."""
+
+    def _write_gitmodules(self, repo: Path, body: str) -> None:
+        (repo / ".gitmodules").write_text(body)
+
+    def test_ssh_preflight_failure_short_circuits(self, tmp_repo, tmp_path):
+        self._write_gitmodules(
+            tmp_repo,
+            '[submodule "vendor/x"]\n'
+            "\tpath = vendor/x\n"
+            "\turl = git@github.com:example/x.git\n",
+        )
+        # Shim ssh to fail with Permission denied. Also shim git so that
+        # IF the script doesn't short-circuit, we'd see a distinguishable
+        # generic failure — but the expectation is the pre-flight catches it.
+        bin_dir = tmp_path / "bin"
+        _make_ssh_shim(
+            bin_dir,
+            "git@github.com: Permission denied (publickey).",
+            exit_code=255,
+        )
+        # Sentinel: if git submodule were called, this stderr would appear.
+        _make_git_shim(bin_dir, "SHOULD NOT REACH submodule init")
+        result = _run_doctor(tmp_repo, extra_path=bin_dir)
+        assert result.returncode == 1
+        assert "SSH pre-flight failed" in result.stderr
+        assert "github.com" in result.stderr
+        assert "apple-use-keychain" in result.stderr
+        # Submodule init must not have been invoked.
+        assert "SHOULD NOT REACH" not in result.stderr
+
+    def test_https_only_gitmodules_skips_preflight(self, tmp_repo, tmp_path):
+        """No SSH URLs → no ssh invocation. We prove this by shimming ssh
+        to error loudly; if pre-flight ran, that error would surface."""
+        self._write_gitmodules(
+            tmp_repo,
+            '[submodule "vendor/x"]\n'
+            "\tpath = vendor/x\n"
+            "\turl = https://github.com/example/x.git\n",
+        )
+        bin_dir = tmp_path / "bin"
+        _make_ssh_shim(bin_dir, "PREFLIGHT SHOULD NOT INVOKE SSH", exit_code=1)
+        # Generic git failure so the test exits 1 deterministically without
+        # network. We only care that ssh wasn't called.
+        _make_git_shim(bin_dir, "fatal: some non-auth problem")
+        result = _run_doctor(tmp_repo, extra_path=bin_dir)
+        assert result.returncode == 1
+        assert "PREFLIGHT SHOULD NOT INVOKE SSH" not in result.stderr
+        assert "SSH pre-flight failed" not in result.stderr
+
+    def test_no_preflight_flag_skips_ping(self, tmp_repo, tmp_path):
+        """Even with SSH URLs in .gitmodules, --no-preflight must skip the
+        ssh call entirely — operator opt-out for the 3-second timeout."""
+        self._write_gitmodules(
+            tmp_repo,
+            '[submodule "vendor/x"]\n'
+            "\tpath = vendor/x\n"
+            "\turl = git@github.com:example/x.git\n",
+        )
+        bin_dir = tmp_path / "bin"
+        _make_ssh_shim(bin_dir, "PREFLIGHT SHOULD NOT INVOKE SSH", exit_code=1)
+        _make_git_shim(bin_dir, "fatal: some non-auth problem")
+        result = _run_doctor(
+            tmp_repo, extra_path=bin_dir, extra_args=["--no-preflight"]
+        )
+        assert result.returncode == 1
+        assert "PREFLIGHT SHOULD NOT INVOKE SSH" not in result.stderr
+        assert "SSH pre-flight failed" not in result.stderr
+
+    def test_ssh_preflight_success_proceeds_to_submodule_init(self, tmp_repo, tmp_path):
+        """When ssh -T returns GitHub's success banner, the pre-flight passes
+        and the script continues to submodule init. We prove this by
+        shimming git submodule with a sentinel error and asserting the
+        sentinel appears in stderr — that's only possible if the
+        submodule call actually ran."""
+        self._write_gitmodules(
+            tmp_repo,
+            '[submodule "vendor/x"]\n'
+            "\tpath = vendor/x\n"
+            "\turl = git@github.com:example/x.git\n",
+        )
+        bin_dir = tmp_path / "bin"
+        _make_ssh_shim(
+            bin_dir,
+            "Hi gregoryfoster! You've successfully authenticated, "
+            "but GitHub does not provide shell access.",
+            exit_code=1,
+        )
+        _make_git_shim(bin_dir, "SUBMODULE_INIT_REACHED_SENTINEL")
+        result = _run_doctor(tmp_repo, extra_path=bin_dir)
+        assert result.returncode == 1  # sentinel fails the init deliberately
+        assert "SUBMODULE_INIT_REACHED_SENTINEL" in result.stderr
+        assert "SSH pre-flight failed" not in result.stderr
+
+    def test_ssh_preflight_host_key_failure_short_circuits_with_keyscan_hint(
+        self, tmp_repo, tmp_path
+    ):
+        """Host-key-verification failures are classified separately from
+        auth failures and surface the keyscan-based remediation, not the
+        agent/keychain one."""
+        self._write_gitmodules(
+            tmp_repo,
+            '[submodule "vendor/x"]\n'
+            "\tpath = vendor/x\n"
+            "\turl = git@github.com:example/x.git\n",
+        )
+        bin_dir = tmp_path / "bin"
+        _make_ssh_shim(
+            bin_dir,
+            "No ED25519 host key is known for github.com and you have requested "
+            "strict checking.\nHost key verification failed.",
+            exit_code=255,
+        )
+        _make_git_shim(bin_dir, "SHOULD NOT REACH submodule init")
+        result = _run_doctor(tmp_repo, extra_path=bin_dir)
+        assert result.returncode == 1
+        assert "host key not trusted" in result.stderr
+        assert "ssh-keyscan" in result.stderr
+        # Agent remediation should NOT appear — wrong rung for this failure.
+        assert "apple-use-keychain" not in result.stderr
+        # Submodule init must not have been invoked.
+        assert "SHOULD NOT REACH" not in result.stderr
+
+    def test_ssh_preflight_mixed_failures_prints_both_remediations(
+        self, tmp_repo, tmp_path
+    ):
+        """Two hosts, two different failure modes: the doctor must print
+        each remediation once and tag each host into the right bucket.
+        Refactors that collapse the two arrays into one would regress
+        this — the test fails if either remediation goes missing."""
+        self._write_gitmodules(
+            tmp_repo,
+            '[submodule "vendor/a"]\n'
+            "\tpath = vendor/a\n"
+            "\turl = git@host-a.example.com:owner/a.git\n"
+            '[submodule "vendor/b"]\n'
+            "\tpath = vendor/b\n"
+            "\turl = git@host-b.example.com:owner/b.git\n",
+        )
+        bin_dir = tmp_path / "bin"
+        _make_ssh_shim_per_host(
+            bin_dir,
+            {
+                "host-a.example.com": (
+                    "git@host-a.example.com: Permission denied (publickey).",
+                    255,
+                ),
+                "host-b.example.com": (
+                    "No ED25519 host key is known for host-b.example.com.\n"
+                    "Host key verification failed.",
+                    255,
+                ),
+            },
+        )
+        _make_git_shim(bin_dir, "SHOULD NOT REACH submodule init")
+        result = _run_doctor(tmp_repo, extra_path=bin_dir)
+        assert result.returncode == 1
+        # Each host appears in the corresponding bucket's diagnostic line.
+        assert "agent cannot authenticate to: host-a.example.com" in result.stderr
+        assert "host key not trusted for: host-b.example.com" in result.stderr
+        # Both remediation blocks rendered.
+        assert "apple-use-keychain" in result.stderr
+        assert "ssh-keyscan" in result.stderr
+        # Pre-flight short-circuited before submodule init.
+        assert "SHOULD NOT REACH" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+class TestCLISurface:
+    def test_help_documents_no_preflight_flag(self):
+        result = subprocess.run(
+            ["bash", str(SCRIPT), "--help"], capture_output=True, text=True
+        )
+        assert result.returncode == 0
+        assert "--no-preflight" in result.stdout
+
+    def test_help_mentions_host_key_remediation_path(self):
+        """The host-key failure mode is a distinct path documented in
+        --help. Pin a stable substring so a doc-only refactor that
+        removes the mention surfaces as a test failure."""
+        result = subprocess.run(
+            ["bash", str(SCRIPT), "--help"], capture_output=True, text=True
+        )
+        assert result.returncode == 0
+        assert "host-key" in result.stdout or "ssh-keyscan" in result.stdout
+
+    def test_unknown_flag_still_exits_2(self):
+        result = subprocess.run(
+            ["bash", str(SCRIPT), "--bogus"], capture_output=True, text=True
+        )
+        assert result.returncode == 2
+        assert "unknown option" in result.stderr


### PR DESCRIPTION
## Summary

- Classifies submodule-init failures by SSH/HTTPS auth signature (`Permission denied (…)`, `Could not read from remote repository`, `Authentication failed for 'https://`) and prints a targeted remediation block instead of the previous generic line.
- Adds an SSH pre-flight ping (`ssh -T -o StrictHostKeyChecking=yes`) that runs only when `.gitmodules` references SSH remotes — surfaces auth failures and host-key-verification failures with separate remediation blocks before submodule init produces a wall of clone errors. Skippable with `--no-preflight`.
- Captures submodule init stderr via a named fifo + explicitly-backgrounded tee with `wait "$TEE_PID"` so live output is preserved and the pattern is portable across bash 3.2+ (default on macOS without Homebrew).

Closes #50.

## What the operator sees

**Before** — opaque rollback after a wall of clone errors:
```
fatal: clone of 'git@github.com:gregoryfoster/skills.git' into submodule path … failed
…
doctor: 'git submodule update --init --recursive' failed
```

**After** — same git output, plus targeted next steps:
```
doctor: the auth check above failed — auth to one of the submodule remotes was refused.
  1. SSH agent not reachable from this shell.        ssh-add -l
  2. Agent reachable but empty.                      ssh-add --apple-use-keychain ~/.ssh/id_ed25519
  3. Auth works in your terminal but not from a wrapper script.
  4. Public submodule, no SSH credentials available.
```

Or, for the host-key case (`StrictHostKeyChecking=yes` rejects unknown hosts):
```
doctor: SSH pre-flight failed — host key not trusted for: github.com
  ssh-keyscan github.com >> ~/.ssh/known_hosts
```

## Iteration

3 CR rounds, 19 numbered findings. Notable design pivots:
- `StrictHostKeyChecking=accept-new` → `=yes` per round 1 (security: don't silently expand known_hosts).
- `Permission denied (publickey)` → `Permission denied (` per round 1 (catches password / multi-method variants).
- Process-substitution + `wait` → named fifo + `wait $TEE_PID` per round 2 (full bash-3.2 portability).
- EXIT trap moved above `mkfifo` per round 3 (no tempdir leak on partial-init failure).

## Test plan

- [x] `pytest tests/structural/` — 806 passed, 11 skipped (was 791 before this branch). 15 new behavioural tests in `tests/structural/test_doctor_ssh_remediation.py` covering: each auth signature (publickey/password/multi-method/HTTPS), generic-failure no-false-positive guard, pre-flight short-circuit (auth-failure / HTTPS-only-skip / `--no-preflight` / success / host-key / multi-host mixed), and CLI surface (`--help` pins, unknown-flag rejection).
- [x] `shellcheck skills/managing-skills/scripts/doctor.sh` — clean.
- [x] Smoke verified on the live repo: `bash skills/managing-skills/scripts/doctor.sh` exits 0 silently in healthy state; `--verbose` reports "all skill symlinks resolve"; `--help` documents the new flag and host-key path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
