### PR TITLE
#52 fix: CR follow-up — Phase 14 push.sh uses -python-fastapi variant

### DIFF
--- a/skills/init-project-fastapi/SKILL.md
+++ b/skills/init-project-fastapi/SKILL.md
@@ -439,7 +439,7 @@ Commit message body should list all key scaffold components (see AGENTS.md commi
 ### Phase 14 — Push
 
 ```bash
-bash skills/shipping-work/scripts/push.sh
+bash skills/shipping-work-python-fastapi/scripts/push.sh
 ```
 
 **If the push is rejected with `! [rejected] main -> main (fetch first)`,** the GitHub repo was created via the UI with "Add LICENSE" or "Add README" checked, leaving an unrelated initial commit on `main`. Prevent it next time by creating the repo with no LICENSE/README; recover this time by rebasing onto the remote and re-pushing:
@@ -447,7 +447,7 @@ bash skills/shipping-work/scripts/push.sh
 ```bash
 # Only run when the push above was rejected for divergent history.
 git pull --rebase --allow-unrelated-histories origin main
-bash skills/shipping-work/scripts/push.sh
+bash skills/shipping-work-python-fastapi/scripts/push.sh
 ```
 
 ### Phase 15 — GitHub issue


### PR DESCRIPTION
## Summary

Recovery PR for a CR round 1 fix that was approved against #53 but failed to push before the parent PR merged.

CR finding 1 against #53: Phase 14's `bash skills/shipping-work/scripts/push.sh` referenced the stack-neutral path that #53's new Phase 10 filter no longer symlinks. Both invocations (initial push + rebase-and-retry) now point at `skills/shipping-work-python-fastapi/scripts/push.sh`, which the filter guarantees to exist.

Re-opens nothing. #52 stays resolved by #53 + this follow-up together.

## Test plan

- [x] `grep -n "skills/shipping-work/scripts/push.sh" skills/init-project-fastapi/SKILL.md` returns no matches after fix.
- [x] Pre-commit `Structural Tests` hook passed on the cherry-picked commit.
- [ ] Next FastAPI bootstrap run reaches Phase 14 without `No such file or directory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
