### PR TITLE
#55 feat: worktree-destroy.sh --force flag for submodule worktrees

### DIFF
--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -113,14 +113,17 @@ If the branch is **descoped** (will not be merged), document why before Phase 5:
 bash scripts/worktree-destroy.sh <branch>
 bash scripts/worktree-destroy.sh <branch> --descoped "<reason>"
 bash scripts/worktree-destroy.sh <branch> --base <ref>   # verify merge into <ref> instead of project default
+bash scripts/worktree-destroy.sh <branch> --force        # required when the worktree contains submodules
 ```
 
 The script:
 - Verifies the branch is an ancestor of the base ref (the actual "merged" check, not just "pushed"). Default base resolution: `.skills/default_branch` → origin's HEAD → `main`, preferring `origin/<base>` over local `<base>` so unpublished local merges don't fool the gate. Pass `--base <ref>` to verify against an explicit non-default integration branch instead (e.g., `batch/<x>` in a multi-agent orchestration); the supplied ref is used as-given. Refuses if the branch is not merged AND `--descoped <reason>` was not supplied.
 - If `<worktree>/.port` exists, kills any process bound to that port via `lsof -ti tcp:<port>` (portable to macOS + Linux). Falls back to a warning if `lsof` isn't installed.
-- Runs `git worktree remove <path>`
+- Runs `git worktree remove <path>` (or `git worktree remove --force <path>` if `--force` was supplied)
 - Runs `git worktree prune` to clean stale metadata
 - Exits 0 on success, 1 on Iron Law violation (unmerged work without `--descoped`), 2 on tooling failure
+
+**When to pass `--force`:** git's `worktree remove` refuses to act on worktrees containing checked-out submodules (`fatal: working trees containing submodules cannot be moved or removed`). If the project ships submodules (e.g., `skills-vendor/*` consumed via `managing-skills`), every destroy will hit this. Pass `--force` to propagate `--force` to `git worktree remove`. The Iron Law's merge gate is unaffected — `--force` only controls the final removal mechanics. **Caveat:** `--force` also bypasses git's dirty-working-tree refusal, so any uncommitted changes in the worktree are silently discarded; verify the worktree is clean before forcing.
 
 The branch ref itself is **not** deleted — that's a separate decision. Use `git branch -d <branch>` afterward if you also want to drop the local ref.
 

--- a/skills/using-git-worktrees/SKILL.md
+++ b/skills/using-git-worktrees/SKILL.md
@@ -123,7 +123,7 @@ The script:
 - Runs `git worktree prune` to clean stale metadata
 - Exits 0 on success, 1 on Iron Law violation (unmerged work without `--descoped`), 2 on tooling failure
 
-**When to pass `--force`:** git's `worktree remove` refuses to act on worktrees containing checked-out submodules (`fatal: working trees containing submodules cannot be moved or removed`). If the project ships submodules (e.g., `skills-vendor/*` consumed via `managing-skills`), every destroy will hit this. Pass `--force` to propagate `--force` to `git worktree remove`. The Iron Law's merge gate is unaffected — `--force` only controls the final removal mechanics. **Caveat:** `--force` also bypasses git's dirty-working-tree refusal, so any uncommitted changes in the worktree are silently discarded; verify the worktree is clean before forcing.
+**When to pass `--force`:** git's `worktree remove` refuses to act on worktrees containing checked-out submodules (`fatal: working trees containing submodules cannot be moved or removed`). If the project ships submodules (e.g., `skills-vendor/*` consumed via `managing-skills`), every destroy will hit this — pass `--force` to bypass git's submodule refusal. The Iron Law's merge gate is unaffected — `--force` only controls the final removal mechanics. **Caveat:** `--force` also bypasses git's dirty-working-tree refusal, so any uncommitted changes in the worktree are silently discarded; verify the worktree is clean before forcing.
 
 The branch ref itself is **not** deleted — that's a separate decision. Use `git branch -d <branch>` afterward if you also want to drop the local ref.
 

--- a/skills/using-git-worktrees/scripts/worktree-destroy.sh
+++ b/skills/using-git-worktrees/scripts/worktree-destroy.sh
@@ -236,28 +236,28 @@ fi
 # keep it opt-in rather than auto-detecting submodules — silent auto-force
 # would also silently discard uncommitted changes in the worktree.
 #
-# Capture stderr on failure so we can hint at --force when git's refusal looks
-# like the submodule case. The Iron Law's merge gate has already passed by
-# this point; this hint is purely about the final removal mechanics.
-REMOVE_ERR=""
-if [[ $FORCE -eq 1 ]]; then
-  if ! REMOVE_ERR=$(git worktree remove --force "$WORKTREE_PATH" 2>&1 >/dev/null); then
-    echo "ERROR: git worktree remove --force failed:" >&2
-    echo "$REMOVE_ERR" >&2
-    exit 2
+# Capture stderr so we can (a) hint at --force when git's refusal looks like
+# the submodule case, and (b) surface git's non-fatal warnings on success
+# (which the prior fire-and-forget invocation passed straight to the terminal
+# — preserve that visibility under the captured-stderr pattern). The Iron
+# Law's merge gate has already cleared (passed or explicitly descoped) by
+# this point; the hint is purely about removal mechanics.
+REMOVE_ARGS=()
+[[ $FORCE -eq 1 ]] && REMOVE_ARGS+=(--force)
+# ${arr[@]+"${arr[@]}"} is the bash-3.2-safe expansion for "maybe-empty array
+# under set -u" — macOS still ships bash 3.2, where a plain "${arr[@]}" on an
+# empty array trips nounset.
+if ! REMOVE_ERR=$(git worktree remove ${REMOVE_ARGS[@]+"${REMOVE_ARGS[@]}"} "$WORKTREE_PATH" 2>&1 >/dev/null); then
+  echo "ERROR: git worktree remove failed:" >&2
+  echo "$REMOVE_ERR" >&2
+  if [[ $FORCE -eq 0 && "$REMOVE_ERR" == *submodule* ]]; then
+    echo "" >&2
+    echo "Hint: the worktree contains submodules. Re-run with --force to bypass." >&2
+    echo "      (--force also bypasses git's dirty-tree check; verify the worktree is clean first.)" >&2
   fi
-else
-  if ! REMOVE_ERR=$(git worktree remove "$WORKTREE_PATH" 2>&1 >/dev/null); then
-    echo "ERROR: git worktree remove failed:" >&2
-    echo "$REMOVE_ERR" >&2
-    if [[ "$REMOVE_ERR" == *submodule* ]]; then
-      echo "" >&2
-      echo "Hint: the worktree contains submodules. Re-run with --force to bypass." >&2
-      echo "      (--force also bypasses git's dirty-tree check; verify the worktree is clean first.)" >&2
-    fi
-    exit 2
-  fi
+  exit 2
 fi
+[[ -n "$REMOVE_ERR" ]] && printf '%s\n' "$REMOVE_ERR" | sed 's/^/WARN: /' >&2
 git worktree prune || exit 2
 
 # Post-removal sweep: warn (do not fail) if anything still references the path.

--- a/skills/using-git-worktrees/scripts/worktree-destroy.sh
+++ b/skills/using-git-worktrees/scripts/worktree-destroy.sh
@@ -3,11 +3,11 @@
 # Destroys the worktree for <branch>. Refuses if the branch is NOT merged
 # into the base ref AND --descoped <reason> was not supplied (Iron Law).
 #
-# Usage: bash scripts/worktree-destroy.sh <branch> [--base <ref>] [--descoped <reason>] [--help]
+# Usage: bash scripts/worktree-destroy.sh <branch> [--base <ref>] [--descoped <reason>] [--force] [--help]
 set -euo pipefail
 
 usage() {
-  echo "Usage: bash scripts/worktree-destroy.sh <branch> [--base <ref>] [--descoped <reason>]"
+  echo "Usage: bash scripts/worktree-destroy.sh <branch> [--base <ref>] [--descoped <reason>] [--force]"
   echo ""
   echo "Destroys the worktree for <branch> (resolved via the same path scheme"
   echo "as worktree-create.sh). Iron Law: refuses if the branch has NOT been"
@@ -35,6 +35,13 @@ usage() {
   echo "  Precedence: --descoped takes precedence over --base. If both are"
   echo "  supplied, the merge check is skipped entirely and --base is ignored."
   echo ""
+  echo "  --force propagates to 'git worktree remove --force'. Required when the"
+  echo "  worktree contains checked-out submodules (git refuses to remove those"
+  echo "  without --force). Note: --force ALSO bypasses git's dirty-working-tree"
+  echo "  check, so any uncommitted changes in the worktree are discarded. The"
+  echo "  Iron Law's merge gate is unaffected — --force only changes removal"
+  echo "  mechanics, not merge verification."
+  echo ""
   echo "Does NOT delete the branch ref. Use 'git branch -d <branch>' afterward"
   echo "if you also want to drop the local ref."
   echo ""
@@ -60,6 +67,7 @@ shift
 DESCOPED=0
 DESCOPE_REASON=""
 BASE_OVERRIDE=""
+FORCE=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --descoped)
@@ -80,6 +88,10 @@ while [[ $# -gt 0 ]]; do
         exit 2
       fi
       shift 2
+      ;;
+    --force)
+      FORCE=1
+      shift
       ;;
     *)
       echo "ERROR: unknown flag '$1'" >&2
@@ -219,7 +231,33 @@ if [[ -n "$PIDS" ]]; then
   fi
 fi
 
-git worktree remove "$WORKTREE_PATH" || exit 2
+# Removal: pass --force only when explicitly requested. --force bypasses BOTH
+# git's submodule-presence refusal AND its dirty-working-tree refusal, so we
+# keep it opt-in rather than auto-detecting submodules — silent auto-force
+# would also silently discard uncommitted changes in the worktree.
+#
+# Capture stderr on failure so we can hint at --force when git's refusal looks
+# like the submodule case. The Iron Law's merge gate has already passed by
+# this point; this hint is purely about the final removal mechanics.
+REMOVE_ERR=""
+if [[ $FORCE -eq 1 ]]; then
+  if ! REMOVE_ERR=$(git worktree remove --force "$WORKTREE_PATH" 2>&1 >/dev/null); then
+    echo "ERROR: git worktree remove --force failed:" >&2
+    echo "$REMOVE_ERR" >&2
+    exit 2
+  fi
+else
+  if ! REMOVE_ERR=$(git worktree remove "$WORKTREE_PATH" 2>&1 >/dev/null); then
+    echo "ERROR: git worktree remove failed:" >&2
+    echo "$REMOVE_ERR" >&2
+    if [[ "$REMOVE_ERR" == *submodule* ]]; then
+      echo "" >&2
+      echo "Hint: the worktree contains submodules. Re-run with --force to bypass." >&2
+      echo "      (--force also bypasses git's dirty-tree check; verify the worktree is clean first.)" >&2
+    fi
+    exit 2
+  fi
+fi
 git worktree prune || exit 2
 
 # Post-removal sweep: warn (do not fail) if anything still references the path.


### PR DESCRIPTION
## Summary

- Adds an opt-in `--force` flag to `using-git-worktrees/scripts/worktree-destroy.sh` that propagates to `git worktree remove --force`, unblocking the cleanup path on any project whose worktree contains checked-out submodules (e.g. consumers using `gregoryfoster/skills` via `skills-vendor/*`).
- When the bare `git worktree remove` fails with a submodule-shaped error, the script now surfaces git's raw refusal plus an explicit hint pointing at `--force` (with a dirty-tree caveat) so operators aren't left interpreting the fatal alone.
- Updates `SKILL.md` Phase 5 to document the flag, when to use it, and the dirty-tree caveat.

## Design choice — Option A (opt-in) over auto-detect

The issue framed this as predictability vs. magic; the stronger reason for opt-in is that `git worktree remove --force` bypasses **two** checks, not one — both the submodule refusal **and** the dirty-working-tree refusal. The Iron Law's merge gate guarantees "branch merged into base" but does **not** guarantee the worktree is clean. Silent auto-force would strip the dirty-tree protection any time a submodule was present, discarding uncommitted scratch/`.env`/debug edits without warning. Opt-in keeps the dirty-tree gate intact by default; the explicit flag signals "I've verified the worktree is clean."

The Iron Law itself is untouched — `--force` only changes final removal mechanics, not merge verification (`--force` on an unmerged branch without `--descoped` still exits 1).

## Test plan

Smoke-tested locally on git 2.39.3 (Apple Git-145):

- [x] Normal destroy (no submodules) — unchanged, exits 0
- [x] Submodule-containing worktree without `--force` — exits 2, surfaces git's raw `fatal: working trees containing submodules cannot be moved or removed` plus the new hint pointing to `--force` and the dirty-tree caveat
- [x] Same worktree with `--force` — exits 0, worktree removed
- [x] Unmerged branch + `--force` — Iron Law still blocks, exits 1
- [x] `--descoped` + `--force` together — composes cleanly, exits 0
- [x] Unknown flag — still rejected
- [x] `--help` output reflects the new flag
- [x] `bash -n` syntax check

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
