### PR TITLE
#74 fix: mark socraticode-policy block in AGENTS.md template; add unmarked-heading fallback

### DIFF
--- a/skills/init-project-fastapi/SKILL.md
+++ b/skills/init-project-fastapi/SKILL.md
@@ -173,7 +173,9 @@ Adapt the template in [`references/agents-md-template.md`](references/agents-md-
 > end include
 ```
 
-When the condition is satisfied, write the inner content with placeholders substituted but **drop the `> Include when …:` and `> end include` marker lines**. When the condition is not satisfied, drop the entire block (markers + content). The markers must never appear in the rendered project file.
+When the condition is satisfied, write the inner content with placeholders substituted but **drop the `> Include when …:` and `> end include` marker lines**. When the condition is not satisfied, drop the entire block (markers + content). These blockquote markers must never appear in the rendered project file.
+
+**Keep the `<!-- BEGIN socraticode-policy -->` / `<!-- END socraticode-policy -->` comments** around the Code Exploration Policy section — they are literal content, not conditional-block syntax, and **must** survive into the rendered `AGENTS.md`. They are the shared dedupe contract with `init-socraticode`: without them a later `init-socraticode` run appends a second policy section (see #74).
 
 Sections in the template: Project Overview, Development Methodology, Environment & Tooling, Code Exploration Policy, Project Layout, Infrastructure, Server Lifecycle, Environment Variables, Common Commands, Agent Skills, Conventions.
 

--- a/skills/init-project-fastapi/references/agents-md-template.md
+++ b/skills/init-project-fastapi/references/agents-md-template.md
@@ -21,9 +21,10 @@ TDD required. Red → Green → Refactor. No production code without a failing t
 
 Python ≥3.13, uv, pytest, ruff. `ty` is available as a **non-gating** type checker (`uv run ty check`) — advisory only; no pre-commit or CI gate.
 
+<!-- BEGIN socraticode-policy -->
 ## Code Exploration Policy
 
-SocratiCode is the preferred semantic-search tool for this repo (once indexed; the index lives in `.socraticodecontextartifacts.json` once `codebase_index` has run). Its MCP tools are **deferred** — schemas load only after a `ToolSearch` prefetch.
+SocratiCode is the preferred semantic-search tool for this repo (once indexed; the artifact manifest lives in `.socraticodecontextartifacts.json`, and the index itself lives in the local Qdrant store + on-disk graph once `codebase_index` has run). Its MCP tools are **deferred** — schemas load only after a `ToolSearch` prefetch.
 
 **Negative rule.** For broad semantic questions ("where is X", "how does Y work", "what depends on Z"), use SocratiCode MCP tools first. Reach for `grep`/`ripgrep` only on exact strings (error messages, log lines, known symbols). Reserve the Explore subagent for path-pattern walks (e.g. "all `*.py` under `src/api/routes/`"), not semantic search.
 
@@ -40,6 +41,7 @@ SocratiCode is the preferred semantic-search tool for this repo (once indexed; t
 Prefetch query — run via `ToolSearch` at session start:
 
 `select:mcp__plugin_socraticode_socraticode__codebase_search,mcp__plugin_socraticode_socraticode__codebase_symbol,mcp__plugin_socraticode_socraticode__codebase_symbols,mcp__plugin_socraticode_socraticode__codebase_flow,mcp__plugin_socraticode_socraticode__codebase_impact,mcp__plugin_socraticode_socraticode__codebase_graph_query,mcp__plugin_socraticode_socraticode__codebase_status,mcp__plugin_socraticode_socraticode__codebase_context,mcp__plugin_socraticode_socraticode__codebase_context_search`
+<!-- END socraticode-policy -->
 
 ## Project Layout
 

--- a/skills/init-socraticode/SKILL.md
+++ b/skills/init-socraticode/SKILL.md
@@ -117,17 +117,20 @@ Follow [`references/code-exploration-policy.md`](references/code-exploration-pol
 
 1. **Policy block** → land exactly one marker-delimited `## Code Exploration
    Policy` section in `<POLICY_FILE>`. Apply in order, so a repo in any prior
-   state converges to a single marked block:
-   a. If a `<!-- BEGIN socraticode-policy -->` … `<!-- END socraticode-policy -->`
-      pair already exists, **replace between the markers**. Otherwise append a
-      fresh marked block.
+   state converges to a single marked block, in place where one already exists:
+   a. **Write the block, preferring the existing position:**
+      - marker pair (`<!-- BEGIN socraticode-policy -->` … `<!-- END
+        socraticode-policy -->`) already exists → **replace between the markers**;
+      - else an unmarked `## Code Exploration Policy` section exists → **replace
+        that section in place** (its heading through the line before the next
+        `##`, or end of file if none follows) with the marked block;
+      - else → **append** a fresh marked block.
    b. **Then, unconditionally,** delete any *other* `## Code Exploration Policy`
-      section **not** enclosed by the marker pair (its heading through the line
-      before the next `##`, or end of file if none follows). This clears the
-      duplicate on repos bootstrapped before the markers existed (e.g. by
-      `init-project-fastapi`) — including repos where an earlier `init-socraticode`
-      run already appended a marked block beside the original unmarked one, so
-      step (a) alone would leave the unmarked copy behind.
+      section **not** enclosed by the marker pair (same heading-to-next-`##`
+      span). Step (a) fixes at most one location; this sweeps any remaining stray
+      copy — e.g. a repo where an earlier `init-socraticode` run appended a marked
+      block beside the original unmarked one, where step (a) takes the marker-pair
+      branch and would otherwise leave the unmarked copy behind.
    Never leave more than one policy section. Adapt the last tool-table row and any
    path examples to this project's real layout.
 2. **SessionStart hook** (when `INSTALL_HOOK=yes`) → write the reminder script

--- a/skills/init-socraticode/SKILL.md
+++ b/skills/init-socraticode/SKILL.md
@@ -118,8 +118,13 @@ Follow [`references/code-exploration-policy.md`](references/code-exploration-pol
 1. **Policy block** → insert the marker-delimited `## Code Exploration Policy`
    section into `<POLICY_FILE>`. If a `<!-- BEGIN socraticode-policy -->` …
    `<!-- END socraticode-policy -->` pair already exists, **replace between the
-   markers** — never append a second copy. Adapt the last tool-table row and any
-   path examples to this project's real layout.
+   markers** — never append a second copy. **Fallback:** if no marker pair exists
+   but an unmarked `## Code Exploration Policy` heading does (repos bootstrapped
+   before the markers existed — e.g. by `init-project-fastapi`), **replace that
+   whole section in place** (heading through the line before the next `##`) with
+   the marked block rather than appending. Only when neither is present do you
+   append a fresh block. Adapt the last tool-table row and any path examples to
+   this project's real layout.
 2. **SessionStart hook** (when `INSTALL_HOOK=yes`) → write the reminder script
    (`.claude/hooks/socraticode-reminder.sh`) and **merge** its hook entry into
    `.claude/settings.json` (create if absent). Dedupe by scanning existing

--- a/skills/init-socraticode/SKILL.md
+++ b/skills/init-socraticode/SKILL.md
@@ -115,16 +115,21 @@ claude mcp remove socraticode
 
 Follow [`references/code-exploration-policy.md`](references/code-exploration-policy.md):
 
-1. **Policy block** → insert the marker-delimited `## Code Exploration Policy`
-   section into `<POLICY_FILE>`. If a `<!-- BEGIN socraticode-policy -->` …
-   `<!-- END socraticode-policy -->` pair already exists, **replace between the
-   markers** — never append a second copy. **Fallback:** if no marker pair exists
-   but an unmarked `## Code Exploration Policy` heading does (repos bootstrapped
-   before the markers existed — e.g. by `init-project-fastapi`), **replace that
-   whole section in place** (heading through the line before the next `##`) with
-   the marked block rather than appending. Only when neither is present do you
-   append a fresh block. Adapt the last tool-table row and any path examples to
-   this project's real layout.
+1. **Policy block** → land exactly one marker-delimited `## Code Exploration
+   Policy` section in `<POLICY_FILE>`. Apply in order, so a repo in any prior
+   state converges to a single marked block:
+   a. If a `<!-- BEGIN socraticode-policy -->` … `<!-- END socraticode-policy -->`
+      pair already exists, **replace between the markers**. Otherwise append a
+      fresh marked block.
+   b. **Then, unconditionally,** delete any *other* `## Code Exploration Policy`
+      section **not** enclosed by the marker pair (its heading through the line
+      before the next `##`, or end of file if none follows). This clears the
+      duplicate on repos bootstrapped before the markers existed (e.g. by
+      `init-project-fastapi`) — including repos where an earlier `init-socraticode`
+      run already appended a marked block beside the original unmarked one, so
+      step (a) alone would leave the unmarked copy behind.
+   Never leave more than one policy section. Adapt the last tool-table row and any
+   path examples to this project's real layout.
 2. **SessionStart hook** (when `INSTALL_HOOK=yes`) → write the reminder script
    (`.claude/hooks/socraticode-reminder.sh`) and **merge** its hook entry into
    `.claude/settings.json` (create if absent). Dedupe by scanning existing

--- a/skills/init-socraticode/references/code-exploration-policy.md
+++ b/skills/init-socraticode/references/code-exploration-policy.md
@@ -19,8 +19,12 @@ the last table row and any path examples to the project's actual layout.
 
 Insert this into `AGENTS.md`. If a `<!-- BEGIN socraticode-policy -->` /
 `<!-- END socraticode-policy -->` pair already exists, **replace the content
-between the markers** rather than appending a second copy. If no `AGENTS.md`
-exists, create one and add the block.
+between the markers** rather than appending a second copy. **Fallback:** if no
+marker pair exists but an unmarked `## Code Exploration Policy` heading does
+(repos bootstrapped before the markers existed — e.g. by `init-project-fastapi`),
+**replace that whole section in place** (the heading through the line before the
+next `##`) with the marked block below, rather than appending a duplicate. If no
+`AGENTS.md` exists, create one and add the block.
 
 ```markdown
 <!-- BEGIN socraticode-policy -->

--- a/skills/init-socraticode/references/code-exploration-policy.md
+++ b/skills/init-socraticode/references/code-exploration-policy.md
@@ -17,14 +17,22 @@ the last table row and any path examples to the project's actual layout.
 
 ## 1. AGENTS.md block (marker-delimited — idempotent)
 
-Insert this into `AGENTS.md`. If a `<!-- BEGIN socraticode-policy -->` /
-`<!-- END socraticode-policy -->` pair already exists, **replace the content
-between the markers** rather than appending a second copy. **Fallback:** if no
-marker pair exists but an unmarked `## Code Exploration Policy` heading does
-(repos bootstrapped before the markers existed — e.g. by `init-project-fastapi`),
-**replace that whole section in place** (the heading through the line before the
-next `##`) with the marked block below, rather than appending a duplicate. If no
-`AGENTS.md` exists, create one and add the block.
+Land exactly one marker-delimited block in `AGENTS.md`, applying these steps in
+order so a repo in any prior state converges to a single marked block:
+
+1. If a `<!-- BEGIN socraticode-policy -->` / `<!-- END socraticode-policy -->`
+   pair already exists, **replace the content between the markers**. Otherwise
+   append the marked block below. (If no `AGENTS.md` exists, create one and add
+   the block.)
+2. **Then, unconditionally,** delete any *other* `## Code Exploration Policy`
+   section **not** enclosed by the marker pair (its heading through the line
+   before the next `##`, or end of file if none follows). This clears the
+   duplicate on repos bootstrapped before the markers existed (e.g. by
+   `init-project-fastapi`) — including repos where an earlier `init-socraticode`
+   run already appended a marked block beside the original unmarked one, so step 1
+   alone would leave the unmarked copy behind.
+
+Never leave more than one policy section.
 
 ```markdown
 <!-- BEGIN socraticode-policy -->

--- a/skills/init-socraticode/references/code-exploration-policy.md
+++ b/skills/init-socraticode/references/code-exploration-policy.md
@@ -18,19 +18,23 @@ the last table row and any path examples to the project's actual layout.
 ## 1. AGENTS.md block (marker-delimited — idempotent)
 
 Land exactly one marker-delimited block in `AGENTS.md`, applying these steps in
-order so a repo in any prior state converges to a single marked block:
+order so a repo in any prior state converges to a single marked block, in place
+where one already exists:
 
-1. If a `<!-- BEGIN socraticode-policy -->` / `<!-- END socraticode-policy -->`
-   pair already exists, **replace the content between the markers**. Otherwise
-   append the marked block below. (If no `AGENTS.md` exists, create one and add
-   the block.)
+1. **Write the block, preferring the existing position:**
+   - a `<!-- BEGIN socraticode-policy -->` / `<!-- END socraticode-policy -->`
+     pair already exists → **replace the content between the markers**;
+   - else an unmarked `## Code Exploration Policy` section exists → **replace that
+     section in place** (its heading through the line before the next `##`, or end
+     of file if none follows) with the marked block below;
+   - else → **append** the marked block below. (If no `AGENTS.md` exists, create
+     one and add the block.)
 2. **Then, unconditionally,** delete any *other* `## Code Exploration Policy`
-   section **not** enclosed by the marker pair (its heading through the line
-   before the next `##`, or end of file if none follows). This clears the
-   duplicate on repos bootstrapped before the markers existed (e.g. by
-   `init-project-fastapi`) — including repos where an earlier `init-socraticode`
-   run already appended a marked block beside the original unmarked one, so step 1
-   alone would leave the unmarked copy behind.
+   section **not** enclosed by the marker pair (same heading-to-next-`##` span).
+   Step 1 fixes at most one location; this sweeps any remaining stray copy — e.g.
+   a repo where an earlier `init-socraticode` run appended a marked block beside
+   the original unmarked one, where step 1 takes the marker-pair branch and would
+   otherwise leave the unmarked copy behind.
 
 Never leave more than one policy section.
 


### PR DESCRIPTION
Closes #74.

## Problem

`init-project-fastapi` Phase 4 wrote the `## Code Exploration Policy` section into `AGENTS.md` **without** the `<!-- BEGIN/END socraticode-policy -->` markers that `init-socraticode` Phase 3 uses to dedupe. On a bootstrapped repo the pair was absent, so a verbatim `init-socraticode` run appended a **second**, silently divergent policy block — breaking the "all file edits are idempotent" invariant. Different seam from #73 (that one is the SessionStart hook); this is the AGENTS.md prose block, and the root cause is a cross-skill contract mismatch.

## Changes

1. **Source fix** — wrap the block in [`agents-md-template.md`](skills/init-project-fastapi/references/agents-md-template.md) with the markers, so producer and consumer share one contract and a re-index is a no-op.
2. **Preservation note** — [`init-project-fastapi` SKILL.md](skills/init-project-fastapi/SKILL.md) Phase 4 now states the HTML-comment markers are literal content that must survive into the rendered file (distinct from the `> Include when` conditional-block syntax), so a future edit doesn't strip them.
3. **Defensive fallback** — [`init-socraticode` SKILL.md](skills/init-socraticode/SKILL.md) Phase 3 and [its reference](skills/init-socraticode/references/code-exploration-policy.md) now replace an **unmarked** `## Code Exploration Policy` section in place, repairing repos bootstrapped before the markers existed (the template fix can't reach those retroactively).
4. **Wording sync** — corrected the divergent "where the index lives" sentence in the template (`.socraticodecontextartifacts.json` is the *manifest*; the index is the Qdrant store + on-disk graph).

## Cohort

Already observed on `CannObserv/replicator` (fixed in-place). Other skill-vendoring repos auto-repair via change (3) on their next `init-socraticode` run; any not re-run soon should be checked directly.

Related: #73 (same invariant, hook side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)