### PR TITLE
#94 feat: gate skill changes on the cohort as a held-out validation split

### DIFF
--- a/.skills/cohort
+++ b/.skills/cohort
@@ -1,4 +1,4 @@
-# Cohort roster for curating-context's cohort-report.sh.
+# Cohort roster for curating-context's cohort-report.sh and score-cohort.sh.
 #
 # One entry per line: an owner/repo slug (read over `gh api`, no clone needed) or
 # an absolute/relative local path. Blank lines and # comments are ignored.
@@ -6,16 +6,46 @@
 # These are the CannObserv repos built on the shared agent-tooling foundation
 # (init-project-fastapi scaffold, managing-skills vendoring, init-socraticode
 # indexing) — the same set that skill-family sweeps target.
+#
+# An entry may carry whitespace-separated key:value annotations:
+#
+#   wave:  which arm of the validation split this repo belongs to
+#   pair:  which matched pair, so an A/B compares like against like
+#
+# Wave A adopts first; wave B is held back so that a later proposal can be tried
+# on it while wave A keeps running the version before it. That staging is the
+# whole reason the roster carries these fields — adopting all twelve at once puts
+# the cohort on one version and forfeits the comparison permanently.
+#
+# Pairs are adjacent in the 2026-08-05 exact baseline, so the two members of a
+# pair started at a comparable size, and the wave assignment within each pair
+# balances the secondary axis (whether the repo already had a Detail Docs index):
+# two indexed repos in each arm. Rationale, metric, and adoption rule:
+# skills/curating-context/references/validation-gate.md
 
-CannObserv/archiver
-CannObserv/cannobserv
-CannObserv/cli
-CannObserv/notifier
-CannObserv/cannabis.observer-wordpress
-CannObserv/observo
-CannObserv/usa-wa
-CannObserv/address-validator
-CannObserv/wslcb-licensing-tracker
-CannObserv/power-map
-CannObserv/watcher
-CannObserv/replicator
+# pair 1 — 52,953 / 49,103
+CannObserv/usa-wa                        wave:a pair:1
+CannObserv/cannabis.observer-wordpress   wave:b pair:1
+
+# pair 2 — 28,110 / 25,949
+CannObserv/observo                       wave:a pair:2
+CannObserv/cannobserv                    wave:b pair:2
+
+# pair 3 — 14,633 / 19,715. The weakest match in the roster: 29% apart, where
+# every other pair is within 8%. `watcher` has no size neighbour.
+CannObserv/replicator                    wave:a pair:3
+CannObserv/watcher                       wave:b pair:3
+
+# pair 4 — 14,358 / 13,298
+CannObserv/archiver                      wave:a pair:4
+CannObserv/power-map                     wave:b pair:4
+
+# pair 5 — 6,013 / 6,322. Both within 6% of budget, so both arms will close
+# their gap completely and the pair is expected to be uninformative.
+CannObserv/cli                           wave:a pair:5
+CannObserv/address-validator             wave:b pair:5
+
+# pair 6 — 5,468 / 5,331. Both already under budget: no gap to close, so this
+# pair contributes to the safety gates only.
+CannObserv/notifier                      wave:a pair:6
+CannObserv/wslcb-licensing-tracker       wave:b pair:6

--- a/skills/curating-context/SKILL.md
+++ b/skills/curating-context/SKILL.md
@@ -337,7 +337,7 @@ returns every few runs and is re-litigated from scratch.
 validation split, and `score-cohort.sh` scores the arm running a proposal against
 the arm running the version before it. Adoption needs a win on every informative
 pair and a clean sweep of the safety gates; anything else, "no measurable
-difference" included, is a rejection. The split, the metric, and what the gate
+difference" included, blocks adoption. The split, the metric, and what the gate
 cannot see: [references/validation-gate.md](references/validation-gate.md).
 
 Commit the ledger with the edits, on a branch, and open a PR whose body carries:

--- a/skills/curating-context/SKILL.md
+++ b/skills/curating-context/SKILL.md
@@ -4,7 +4,7 @@ description: Curates a repo's agent-context surface — AGENTS.md and the refere
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git, bash, and python3. Optionally uses gh for issue verification and the cohort roll-up, and ANTHROPIC_API_KEY for exact token counts.
 metadata:
   author: gregoryfoster
-  version: "1.1"
+  version: "1.2"
   triggers: curate context, context budget, hone AGENTS.md, trim AGENTS.md, prune context
 ---
 
@@ -65,7 +65,8 @@ Two mechanics enforce this:
   **Always pass it when surveying a repo you are not curating.** Without it, a
   read-only-looking survey leaves an untracked file behind in every repo it
   touched.
-- `cohort-report.sh` reads ledgers over `gh api` and never clones or writes.
+- `cohort-report.sh` and `score-cohort.sh` read ledgers over `gh api` and never
+  clone or write.
 
 A cohort ledger therefore fills in as each repo adopts the skill, not from one
 central sweep. `cohort-report.sh` reporting "no ledger" for a member is the
@@ -298,6 +299,10 @@ Re-run Phase 1 and assert, before committing:
   exactly the paraphrase-in-transit Phase 5 forbids. A dropped line is the one
   failure mode of this skill that a token count cannot detect — the count looks
   better for it.
+
+  Carry the verdict onto the ledger row in Phase 7 (`--no-loss ok`). The
+  validation gate treats a missing verdict as unscorable rather than as a pass,
+  so a run that skipped this phase cannot clear it by silence.
 - `links.dead` is empty, and no new orphan appeared.
 - `policy.tokens` is at or under budget, or the Phase 4 report explains why not.
 - The repo's own test suite still passes, if it asserts on policy-file content.
@@ -309,7 +314,7 @@ Re-run Phase 1 and assert, before committing:
 bash "<SKILL_SCRIPTS>/measure-context.sh" --exact \
   | bash "<SKILL_SCRIPTS>/record-telemetry.sh" \
       --actions "demote:Project Layout,prune:Conventions,fix:dead-link" \
-      --print-trend
+      --no-loss ok --print-trend
 ```
 
 Tag `--actions` honestly and specifically. The tags are the only thing that lets
@@ -327,6 +332,13 @@ When a change to this skill is tried and abandoned, record it in
 [references/rejected-changes.md](references/rejected-changes.md) with what refuted
 it. A rejection is negative feedback: without the record the same plausible idea
 returns every few runs and is re-litigated from scratch.
+
+**A change to this skill is not adopted on judgement.** The cohort is a held-out
+validation split, and `score-cohort.sh` scores the arm running a proposal against
+the arm running the version before it. Adoption needs a win on every informative
+pair and a clean sweep of the safety gates; anything else, "no measurable
+difference" included, is a rejection. The split, the metric, and what the gate
+cannot see: [references/validation-gate.md](references/validation-gate.md).
 
 Commit the ledger with the edits, on a branch, and open a PR whose body carries:
 the before/after token count, the per-section disposition table, **every relocated

--- a/skills/curating-context/references/budget-and-metrics.md
+++ b/skills/curating-context/references/budget-and-metrics.md
@@ -203,6 +203,8 @@ access to any other repo.
 | `tokens_live` | policy + reachable live reference docs |
 | `docs_total`, `docs_orphaned` | live doc count, and how many nothing links |
 | `links_dead` | broken relative links in the curated surface |
+| `no_loss` | `prove-no-loss.sh`'s verdict — `ok`, `failed`, `skipped`, or `null` when the check was not run. A safety field, not a score: [the validation gate](validation-gate.md) reads it to reject a change that reduced tokens by dropping content, which no token count can distinguish from a good run. `null` is unscorable, never a pass. |
+| `skill_version`, `skill_commit` | which version of this skill produced the row; `null` on rows predating the field |
 | `top_section`, `top_section_share` | largest section and its % of the file |
 | `delta_tokens`, `delta_days` | change since the previous row for this file; `null` on the first |
 | `actions` | action tags — see below |
@@ -259,6 +261,13 @@ comparison cannot be mistaken for "no change yet".
 
 Roster in `.skills/cohort`, one `owner/repo` slug or local path per line; `#`
 comments allowed. Repos with no ledger are reported rather than skipped.
+
+An entry may also carry `wave:` and `pair:` annotations. The roll-up prints the
+resulting split and how many members of each arm have adopted;
+`score-cohort.sh` is what acts on it. Both scripts read the roster through one
+parser in `_context-lib.sh`, so they cannot disagree about which repo is in which
+arm — a second opinion about the experiment's own assignment would be worse than
+no experiment. See [validation-gate.md](validation-gate.md).
 
 Before a repo adopts the skill it has no ledger, and that is the expected state —
 not a failure, and not something to fix by writing a ledger into it. Ledgers

--- a/skills/curating-context/references/validation-gate.md
+++ b/skills/curating-context/references/validation-gate.md
@@ -1,0 +1,169 @@
+# The Validation Gate
+
+Every learning folded into this skill so far was accepted because it seemed right
+to whoever proposed it. Six went in from the first live run alone. That is exactly
+the failure mode a held-out validation set exists to prevent, and
+[Library Drift](https://arxiv.org/html/2605.19576v1) names the consequence:
+persistent skill artifacts become the degradation substrate, "the frozen-weight
+counterpart to catastrophic forgetting."
+
+[Microsoft's SkillOpt](https://www.microsoft.com/en-us/research/blog/skillopt-agent-skills-as-trainable-parameters/)
+treats the skill file as a trainable parameter against a frozen model, and its
+central control is a binary gate: a revision "is adopted only if it scores
+strictly higher than the current skill on the held-out validation split." Across
+six benchmarks, seven models and three execution modes it was best or tied-best in
+all 52 cells.
+
+**The twelve cohort repos are the held-out split.** That is the thing most skills
+cannot manufacture, and it is the only reason this gate is buildable here.
+
+```bash
+bash "<SKILL_SCRIPTS>/score-cohort.sh" --treatment b --control a
+```
+
+Exit 0 adopt, 3 reject, 5 inconclusive. The script reports; it never writes and
+never adopts. [rejected-changes.md](rejected-changes.md) is where a rejection
+goes.
+
+## The unit of comparison is a repo's first curation
+
+A repo's first curation and its fifth are not the same task. The first is where
+the skill does the bulk of the work — the whole `docs/` tree gets created, the
+largest section gets demoted, the index gets written — and it is where the
+rubric's quality is most visible. The fifth is maintenance.
+
+So the scored run is **the first ledger row carrying a `skill_version` whose
+actions are not purely `baseline*`**, and the pairs exist so that first-against-
+first is a fair comparison. This is also why the staging matters: if all twelve
+repos adopt on the same day and the same version, every first curation is spent,
+and the only comparisons left are between maintenance runs.
+
+## Staging, and which arm is which
+
+Wave A adopts now. Wave B is held. When a change to the skill is proposed, wave B
+adopts *on the proposed version* while wave A keeps running the version before it.
+
+**Wave A therefore holds the older version, and the first experiment runs
+`--treatment b --control a`.** The script's defaults (`--treatment a`) suit later
+rounds, once A is the arm carrying a proposal. Getting the direction backwards
+turns a winning change into a losing one, which is why the flags are explicit
+rather than inferred from version strings — `1.10` sorts below `1.9`.
+
+## The pairs
+
+Adjacent in the 2026-08-05 exact baseline, so both members of a pair started at a
+comparable size. Within each pair, the wave assignment balances the secondary
+axis — whether the repo already had a Detail Docs index — two indexed repos in
+each arm.
+
+| Pair | Wave A | | Wave B | | Apart |
+|---:|---|---:|---|---:|---:|
+| 1 | `usa-wa` | 52,953 | `cannabis.observer-wordpress` | 49,103 | 7% |
+| 2 | `observo` | 28,110 | `cannobserv` | 25,949 | 8% |
+| 3 | `replicator` | 14,633 | `watcher` | 19,715 | **29%** |
+| 4 | `archiver` | 14,358 | `power-map` | 13,298 | 7% |
+| 5 | `cli` | 6,013 | `address-validator` | 6,322 | 5% |
+| 6 | `notifier` | 5,468 | `wslcb-licensing-tracker` | 5,331 | 3% |
+
+Pair 3 is the weakest match in the roster. `watcher` has no size neighbour —
+every other pair is within 8% — and a difference on pair 3 is partly a difference
+in difficulty. Read it accordingly rather than dropping it.
+
+Pairs 5 and 6 are expected to be **uninformative for effectiveness**, and it is
+better to know that now than to discover it after the run. Pair 6 starts under
+budget: there is no gap to close. Pair 5 starts within 6% of budget, so both arms
+will close their gap completely and the metric saturates. Both pairs still carry
+the safety gates.
+
+**That leaves four informative pairs at best.** A clean sweep of four is p=0.062
+under a one-sided sign test — suggestive, not significant. The gate says so in its
+own output rather than letting a sweep read as proof. Twelve repos is the sample
+that exists; the alternative is not a better experiment but no experiment.
+
+## The metric
+
+Effectiveness is **budget-gap closure**:
+
+```
+gap     = max(0, tokens - budget)
+closure = (gap_before - gap_after) / gap_before
+```
+
+A fraction rather than a token count, because the cohort spans 5,331 to 52,953
+and an absolute reduction would let `usa-wa` decide every verdict on its own.
+
+Closure is **capped at 1.0**: a run that cuts far past the budget scores exactly
+the same as one that lands on it. Over-cutting earns nothing, deliberately —
+`tokens_live` rising while the always-paid cost halves was already recorded as a
+[rejected metric](rejected-changes.md), and rewarding depth of cut here would
+reintroduce the same pressure to delete rather than route.
+
+The cap has a cost: when both arms reach budget, the metric has no room left to
+express a difference. Such a pair is reported as **uninformative — saturated**,
+not as a tie. Calling it a tie would make the adoption rule unsatisfiable for any
+pair that starts close to budget, and "the metric cannot separate them" is a
+different claim from "they are equal."
+
+## The safety gates
+
+Checked before any score, on the treatment arm's scored run:
+
+| Gate | Trips when |
+|---|---|
+| `no_loss` | `prove-no-loss.sh` did not return `ok` |
+| `links_dead` | the curated surface has broken links |
+| `docs_orphaned` | demotion left more orphans than it found |
+
+**Any tripped gate is an outright REJECT, whatever the token numbers say.** A
+change that reduces tokens by losing content is the one failure this skill exists
+to prevent, and no amount of closure buys it back. This is the composite the
+issue asked for, expressed as a veto rather than a weighted sum: a weighted sum
+lets a large enough token win pay for a small content loss, and there is no
+exchange rate at which that trade is acceptable.
+
+Two asymmetries are deliberate:
+
+- **Missing data is never a pass.** A run with no `no_loss` field is unscorable,
+  not ok. `record-telemetry.sh --no-loss` is what puts the verdict on the row, and
+  a run that skipped Phase 6 should not be able to clear a Phase 6 gate by
+  silence.
+- **A control-arm failure is reported, not fatal.** That is the *current* version
+  failing — a finding about today, and worth acting on, but not a reason to refuse
+  tomorrow's proposal.
+
+## The adoption rule
+
+**Adopt only if the treatment wins every informative pair.** Ties, mixed results,
+and "no measurable difference" are all rejections.
+
+A majority rule would be a rule for adopting noise at this sample size. With four
+informative pairs, three-of-four happens 31% of the time by chance alone. The
+sweep requirement is the only threshold that carries any evidential weight here,
+and even it lands at p=0.062.
+
+`--min-pairs` (default 3) is the floor below which the verdict is INCONCLUSIVE
+rather than a rejection. INCONCLUSIVE is **not** a rejection and does not belong
+in `rejected-changes.md`: nothing has been decided, and the proposal is still
+pending evidence. Recording it as a rejection would poison the buffer with
+non-results and teach a later reader that the idea was tested and failed.
+
+## What this gate cannot do
+
+- **It cannot measure quality of judgement.** Closure sees where the tokens went,
+  not whether the right sections were classified A versus B. A change that
+  demotes the wrong things but hits the number will pass. The gates catch loss,
+  not misjudgement.
+- **It cannot run more than once per proposal.** Each repo has one first
+  curation. After both waves have adopted, the split still works for steady-state
+  weekly runs, but the effect sizes are far smaller and the metric shifts from
+  "how much of the gap did it close" to "did it stay under budget without loss."
+- **It cannot gate itself.** The change that introduced this gate — v1.2 — is the
+  last one that ships unvalidated, because at the time it shipped no cohort repo
+  had adopted anything. That is a genuine hole and not a rhetorical one; the
+  honest mitigation is that this change adds scripts and a reference rather than
+  altering the keep/cut rubric that decides what gets moved.
+
+## Not in scope
+
+Automated adoption. The research is consistent that a human approves structural
+changes. This produces the evidence; it does not act on it.

--- a/skills/curating-context/references/validation-gate.md
+++ b/skills/curating-context/references/validation-gate.md
@@ -38,6 +38,19 @@ first is a fair comparison. This is also why the staging matters: if all twelve
 repos adopt on the same day and the same version, every first curation is spent,
 and the only comparisons left are between maintenance runs.
 
+Two details decide whether that run is scored at all:
+
+- **The before-state must come from the same policy file.** A ledger may track
+  more than one — `record-telemetry.sh` computes its own deltas per file — and
+  taking whichever row happens to precede the curation produced a fabricated
+  closure: a repo that really went 50,000 → 9,000 scored **−2900%** against an
+  unrelated file's 6,100, and handed the pair to the other arm.
+- **An untagged run makes the repo unscorable.** `record-telemetry.sh` emits
+  `actions: []` when `--actions` was omitted, and such a row cannot be told from
+  a baseline. Scoring it as a curation would attribute its near-zero closure to
+  the skill version; skipping past it would hide the tagging gap. The gate says
+  "tag it and re-score" instead.
+
 ## Staging, and which arm is which
 
 Wave A adopts now. Wave B is held. When a change to the skill is proposed, wave B
@@ -45,9 +58,20 @@ adopts *on the proposed version* while wave A keeps running the version before i
 
 **Wave A therefore holds the older version, and the first experiment runs
 `--treatment b --control a`.** The script's defaults (`--treatment a`) suit later
-rounds, once A is the arm carrying a proposal. Getting the direction backwards
-turns a winning change into a losing one, which is why the flags are explicit
-rather than inferred from version strings — `1.10` sorts below `1.9`.
+rounds, once A is the arm carrying a proposal.
+
+Getting the direction backwards turns a winning change into a losing one, so the
+gate detects it: when the treatment arm's versions are all *older* than the
+control's, it prints a `WARN` naming the inversion and the flags that fix it.
+Comparison is by numeric component, not by string — `1.10` is newer than `1.9`
+and sorts below it lexically. That ordering drives only the warning, never the
+verdict: a non-numeric component reads as zero, which is fine for a hint and not
+fine for a decision.
+
+The verdict also refuses when **either arm is split across versions**. "Adopt
+only if strictly better" presumes one proposal; an arm running two names no
+coherent change, and a sweep could be carried by whichever version drew the
+easier pairs.
 
 ## The pairs
 
@@ -121,15 +145,23 @@ issue asked for, expressed as a veto rather than a weighted sum: a weighted sum
 lets a large enough token win pay for a small content loss, and there is no
 exchange rate at which that trade is acceptable.
 
-Two asymmetries are deliberate:
+Three asymmetries are deliberate:
 
 - **Missing data is never a pass.** A run with no `no_loss` field is unscorable,
   not ok. `record-telemetry.sh --no-loss` is what puts the verdict on the row, and
   a run that skipped Phase 6 should not be able to clear a Phase 6 gate by
   silence.
+- **A missing verdict is not a failure.** Both block adoption, but only a
+  *recorded* non-`ok` verdict is evidence that anything went wrong. An absent or
+  `skipped` one yields **INCONCLUSIVE**, not REJECT: nothing was refuted, the
+  experiment was run without its safety check, and filing that in
+  `rejected-changes.md` would record the idea as tested and beaten when it was
+  neither. Fix the run and re-score.
 - **A control-arm failure is reported, not fatal.** That is the *current* version
   failing — a finding about today, and worth acting on, but not a reason to refuse
-  tomorrow's proposal.
+  tomorrow's proposal. A missing verdict there is reported separately again,
+  because calling it a failure reads as the shipped skill having dropped content
+  when in fact nobody ran the check.
 
 ## The adoption rule
 
@@ -141,9 +173,14 @@ informative pairs, three-of-four happens 31% of the time by chance alone. The
 sweep requirement is the only threshold that carries any evidential weight here,
 and even it lands at p=0.062.
 
-`--min-pairs` (default 3) is the floor below which the verdict is INCONCLUSIVE
-rather than a rejection. INCONCLUSIVE is **not** a rejection and does not belong
-in `rejected-changes.md`: nothing has been decided, and the proposal is still
+`--min-pairs` (default 3, **minimum 1**) is the floor below which the verdict is
+INCONCLUSIVE rather than a rejection. Zero is refused rather than clamped: a
+verdict computed over no pairs is not a weaker verdict but no verdict, and the
+sweep test reads `0 == 0` as a win — it adopted on no evidence whatever until
+the branch was guarded on `informative` being non-empty as well.
+
+INCONCLUSIVE is **not** a rejection and does not belong in
+`rejected-changes.md`: nothing has been decided, and the proposal is still
 pending evidence. Recording it as a rejection would poison the buffer with
 non-results and teach a later reader that the idea was tested and failed.
 

--- a/skills/curating-context/references/validation-gate.md
+++ b/skills/curating-context/references/validation-gate.md
@@ -38,13 +38,21 @@ first is a fair comparison. This is also why the staging matters: if all twelve
 repos adopt on the same day and the same version, every first curation is spent,
 and the only comparisons left are between maintenance runs.
 
-Two details decide whether that run is scored at all:
+Three details decide whether that run is scored at all:
 
-- **The before-state must come from the same policy file.** A ledger may track
-  more than one — `record-telemetry.sh` computes its own deltas per file — and
-  taking whichever row happens to precede the curation produced a fabricated
-  closure: a repo that really went 50,000 → 9,000 scored **−2900%** against an
-  unrelated file's 6,100, and handed the pair to the other arm.
+- **One policy file per repo — the one measured most recently.** A ledger may
+  track several, so "what did this repo do" is unanswerable until one is named.
+  `score-cohort.sh` and `cohort-report.sh` use the **same rule**, and a test pins
+  them to the same answer: when they disagreed, one ledger yielded two
+  irreconcilable pictures of a single repo, the gate scoring a 100-token prune on
+  `sub/AGENTS.md` (3.3% closure) while the roll-up reported the 43,000-token
+  curation on `AGENTS.md`. If the primary file was never curated the repo is
+  unscorable and the report names both the file and how many others were skipped
+  — better than quietly scoring whichever file happened to be touched first.
+- **The before-state comes from that same file.** Taking whichever row happens to
+  precede the curation produced a fabricated closure: a repo that really went
+  50,000 → 9,000 scored **−2900%** against an unrelated file's 6,100, and handed
+  the pair to the other arm.
 - **An untagged run makes the repo unscorable.** `record-telemetry.sh` emits
   `actions: []` when `--actions` was omitted, and such a row cannot be told from
   a baseline. Scoring it as a curation would attribute its near-zero closure to
@@ -62,11 +70,16 @@ rounds, once A is the arm carrying a proposal.
 
 Getting the direction backwards turns a winning change into a losing one, so the
 gate detects it: when the treatment arm's versions are all *older* than the
-control's, it prints a `WARN` naming the inversion and the flags that fix it.
+control's, it prints a `WARN` naming the inversion and the flags that fix it —
+**and returns INCONCLUSIVE rather than a rejection.** Detection alone was not
+enough. The first implementation warned at the top and then rejected the winning
+change and told the reader to file it in `rejected-changes.md`, twenty lines
+below the warning saying not to trust the result.
+
 Comparison is by numeric component, not by string — `1.10` is newer than `1.9`
-and sorts below it lexically. That ordering drives only the warning, never the
-verdict: a non-numeric component reads as zero, which is fine for a hint and not
-fine for a decision.
+and sorts below it lexically. That ordering decides only whether to *stop*, never
+who wins: a non-numeric component reads as zero, which is fine for refusing to
+score and not fine for scoring.
 
 The verdict also refuses when **either arm is split across versions**. "Adopt
 only if strictly better" presumes one proposal; an arm running two names no
@@ -134,7 +147,7 @@ Checked before any score, on the treatment arm's scored run:
 
 | Gate | Trips when |
 |---|---|
-| `no_loss` | `prove-no-loss.sh` did not return `ok` |
+| `no_loss` | `prove-no-loss.sh` returned a **non-`ok`** verdict. An absent or `skipped` one does not trip the gate — it makes the run *unverified*, which the next section separates out |
 | `links_dead` | the curated surface has broken links |
 | `docs_orphaned` | demotion left more orphans than it found |
 

--- a/skills/curating-context/references/validation-gate.md
+++ b/skills/curating-context/references/validation-gate.md
@@ -40,15 +40,25 @@ and the only comparisons left are between maintenance runs.
 
 Three details decide whether that run is scored at all:
 
-- **One policy file per repo — the one measured most recently.** A ledger may
-  track several, so "what did this repo do" is unanswerable until one is named.
+- **One policy file per repo — the one with the most rows**, ties broken by
+  whichever was measured most recently. A ledger may track several, so "what did
+  this repo do" is unanswerable until one is named.
+
+  Most-recent alone was the first rule and it was too fragile: one incidental
+  `docs/GUIDE.md` baseline re-defined a repo that had curated `AGENTS.md`
+  50,000 → 6,800 over three runs, dropping it out of the experiment and
+  collapsing the roll-up's headline to 4,000 tokens, one run and no net — a
+  number that then fed the cohort total. Row count is what a stray append cannot
+  flip.
+
   `score-cohort.sh` and `cohort-report.sh` use the **same rule**, and a test pins
   them to the same answer: when they disagreed, one ledger yielded two
   irreconcilable pictures of a single repo, the gate scoring a 100-token prune on
   `sub/AGENTS.md` (3.3% closure) while the roll-up reported the 43,000-token
   curation on `AGENTS.md`. If the primary file was never curated the repo is
-  unscorable and the report names both the file and how many others were skipped
-  — better than quietly scoring whichever file happened to be touched first.
+  unscorable and the report names both the file and how many others were skipped;
+  when any ledger held more than one file, the report names which was scored,
+  because the table has no room for the column.
 - **The before-state comes from that same file.** Taking whichever row happens to
   precede the curation produced a fabricated closure: a repo that really went
   50,000 → 9,000 scored **−2900%** against an unrelated file's 6,100, and handed
@@ -84,7 +94,17 @@ score and not fine for scoring.
 The verdict also refuses when **either arm is split across versions**. "Adopt
 only if strictly better" presumes one proposal; an arm running two names no
 coherent change, and a sweep could be carried by whichever version drew the
-easier pairs.
+easier pairs. That test runs *before* the inversion one — an arm that is not
+internally coherent compares older than anything, so diagnosing inversion first
+walked the reader through two problems to reach one.
+
+Every "is this even an experiment?" test compares **canonical** versions, where
+`1.2` and `1.2.0` are one release. Comparing the raw strings made them two, and
+the gate returned ADOPT for a release scored against itself — the mirror of
+adopting on zero evidence. Canonicalisation only strips trailing zero
+components; it is deliberately *not* the numeric key used for the older/newer
+test, which maps every non-numeric component to zero and would collapse
+`2.0-alpha` and `2.0-beta` into one version.
 
 ## The pairs
 
@@ -187,7 +207,14 @@ sweep requirement is the only threshold that carries any evidential weight here,
 and even it lands at p=0.062.
 
 `--min-pairs` (default 3, **minimum 1**) is the floor below which the verdict is
-INCONCLUSIVE rather than a rejection. Zero is refused rather than clamped: a
+INCONCLUSIVE rather than a rejection. Read it against the four-informative-pair
+ceiling above and it says something concrete about how much slack the roster
+has: **the experiment tolerates exactly one pair dropping out.** A second repo
+with no ledger, an untagged run, or a method change anywhere in pairs 1–4 takes
+the round below the floor and there is no verdict to be had. That is the number
+to weigh when deciding how tightly to sequence the adoption issues.
+
+Zero is refused rather than clamped: a
 verdict computed over no pairs is not a weaker verdict but no verdict, and the
 sweep test reads `0 == 0` as a win — it adopted on no evidence whatever until
 the branch was guarded on `informative` being non-empty as well.

--- a/skills/curating-context/references/validation-gate.md
+++ b/skills/curating-context/references/validation-gate.md
@@ -124,7 +124,10 @@ each arm.
 
 Pair 3 is the weakest match in the roster. `watcher` has no size neighbour —
 every other pair is within 8% — and a difference on pair 3 is partly a difference
-in difficulty. Read it accordingly rather than dropping it.
+in difficulty. Read it accordingly rather than dropping it. It is also the one
+row where **wave A holds the smaller member**; every other row runs
+larger-then-smaller, so the ordering looks like a transcription error and is
+not.
 
 Pairs 5 and 6 are expected to be **uninformative for effectiveness**, and it is
 better to know that now than to discover it after the run. Pair 6 starts under

--- a/skills/curating-context/scripts/_context-lib.sh
+++ b/skills/curating-context/scripts/_context-lib.sh
@@ -78,7 +78,8 @@ Provides:
       Parse the cohort roster. Emits one line per entry, fields separated by
       $CTX_US: "<kind><US><entry><US><wave><US><pair>", kind being repo or
       local. wave and pair may be empty. Unknown annotations warn and are
-      ignored. Read it with: IFS="$CTX_US" read -r kind entry wave pair
+      ignored, as does a repeated entry — emitted once, never twice.
+      Read it with: IFS="$CTX_US" read -r kind entry wave pair
 
   ctx_fetch_ledger <kind> <entry> <ledger-path> <branch> <outfile>
       Write one repo's ledger to <outfile>. Returns 0 fetched, 3 no ledger,
@@ -334,7 +335,17 @@ ctx_read_roster() {
   #
   # Unknown keys warn rather than fail, so an older copy of this library reading
   # a newer roster degrades to ignoring the field instead of refusing the file.
+  # A repeated entry is warned about and processed once. Merged silently it
+  # halved an experiment without saying so: a roster declaring four entries and
+  # two pairs produced a report with one pair, no note, and a verdict of ADOPT —
+  # the same "quietly shrinks its own sample" failure that out-of-arm reporting
+  # was added to prevent, reached through a different input error. In the roll-up
+  # the same duplication inflated `runs` to 4 for a two-row ledger.
+  #
+  # bash 3.2 has no associative arrays, so the seen-set is a US-delimited string;
+  # the entry is quoted inside the pattern, which keeps glob characters literal.
   local file="$1" line entry rest field key val wave pair kind
+  local seen="$CTX_US"
   while IFS= read -r line || [ -n "$line" ]; do
     line="${line%%#*}"
     line="${line#"${line%%[![:space:]]*}"}"
@@ -342,6 +353,13 @@ ctx_read_roster() {
     [ -n "$line" ] || continue
     entry="${line%%[[:space:]]*}"
     rest="${line#"$entry"}"
+    case "$seen" in
+      *"$CTX_US$entry$CTX_US"*)
+        printf 'WARN %s: listed more than once in the roster; the repeat is ignored\n' \
+          "$entry" >&2
+        continue ;;
+    esac
+    seen="$seen$entry$CTX_US"
     wave=""
     pair=""
     for field in $rest; do

--- a/skills/curating-context/scripts/_context-lib.sh
+++ b/skills/curating-context/scripts/_context-lib.sh
@@ -15,7 +15,13 @@
 # .claude/hooks/, so ${BASH_SOURCE[0]}'s dirname holds no library.
 set -euo pipefail
 
-usage() {
+# Namespaced, unlike every other script's plain `usage`. Sourcing this file into
+# a caller that defines its own `usage` would otherwise silently replace it, and
+# the caller's --help would print the library's help instead of its own. That is
+# only invisible because all callers happen to parse arguments before sourcing;
+# the first one to call usage() afterwards — an unknown-argument branch, say —
+# would get the wrong text with nothing to indicate why.
+ctx_lib_usage() {
   cat <<'USAGE'
 _context-lib.sh — shared measurement primitives for curating-context
 
@@ -68,6 +74,17 @@ Provides:
       content is a path rather than the file. Split on the tab: field 1 is the
       count, field 2 the reason a caller can log. Split on $CTX_TAB.
 
+  ctx_read_roster <cohort-file>
+      Parse the cohort roster. Emits one line per entry, fields separated by
+      $CTX_US: "<kind><US><entry><US><wave><US><pair>", kind being repo or
+      local. wave and pair may be empty. Unknown annotations warn and are
+      ignored. Read it with: IFS="$CTX_US" read -r kind entry wave pair
+
+  ctx_fetch_ledger <kind> <entry> <ledger-path> <branch> <outfile>
+      Write one repo's ledger to <outfile>. Returns 0 fetched, 3 no ledger,
+      4 unreadable (with a WARN on stderr). Callers needing `repo` entries must
+      check for gh themselves; this reports its absence as unreadable.
+
 Exit codes:
   0  always (this help)
 USAGE
@@ -79,7 +96,7 @@ USAGE
 case "${0##*/}" in
   _context-lib.sh)
     case "${1-}" in
-      -h|--help) usage; exit 0 ;;
+      -h|--help) ctx_lib_usage; exit 0 ;;
     esac
     ;;
 esac
@@ -95,6 +112,15 @@ esac
 # Read only by callers, never within this file, which is what SC2034 reports.
 # shellcheck disable=SC2034
 CTX_TAB="$(printf '\t')"
+
+# The roster's field separator, and deliberately NOT a tab. A roster field may be
+# legitimately empty (an unassigned wave), and `IFS=$'\t' read` collapses runs of
+# tabs into one delimiter because tab is IFS whitespace — so "repo<T>x<T><T>3"
+# would land the pair value in the wave variable and silently mis-assign a repo to
+# the wrong arm of the experiment. A unit separator is not IFS whitespace, so
+# empty fields survive the read exactly as written.
+# shellcheck disable=SC2034
+CTX_US="$(printf '\037')"
 
 CTX_ARCHIVAL_DEFAULT="plans specs research audits archive"
 CTX_ARCHIVAL="${CTX_ARCHIVAL:-$CTX_ARCHIVAL_DEFAULT}"
@@ -294,4 +320,75 @@ ctx_prev_bytes() {
     *) note="$ref:$rel is mode $mode, not a regular file; treating as uncommitted" ;;
   esac
   printf '%s\t%s' "$bytes" "$note"
+}
+
+ctx_read_roster() {
+  # The roster is read by two scripts with different jobs — cohort-report.sh
+  # rolls every member up, score-cohort.sh compares two arms of it — and they
+  # must agree on which repo is in which arm. A second parser would be a second
+  # opinion about the experiment's own assignment.
+  #
+  # Annotations are whitespace-separated key:value fields after the entry:
+  #
+  #   CannObserv/usa-wa   wave:a pair:1
+  #
+  # Unknown keys warn rather than fail, so an older copy of this library reading
+  # a newer roster degrades to ignoring the field instead of refusing the file.
+  local file="$1" line entry rest field key val wave pair kind
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -n "$line" ] || continue
+    entry="${line%%[[:space:]]*}"
+    rest="${line#"$entry"}"
+    wave=""
+    pair=""
+    for field in $rest; do
+      key="${field%%:*}"
+      val="${field#*:}"
+      case "$key" in
+        wave) wave="$(printf '%s' "$val" | tr '[:upper:]' '[:lower:]')" ;;
+        pair) pair="$val" ;;
+        *) printf 'WARN %s: unknown roster annotation "%s" (ignored)\n' \
+             "$entry" "$field" >&2 ;;
+      esac
+    done
+    case "$entry" in
+      /*|.*|~*) kind=local ;;
+      *) kind=repo ;;
+    esac
+    printf '%s%s%s%s%s%s%s\n' \
+      "$kind" "$CTX_US" "$entry" "$CTX_US" "$wave" "$CTX_US" "$pair"
+  done <"$file"
+}
+
+ctx_fetch_ledger() {
+  # `gh api` prints nothing AND exits non-zero on 404, so an empty-output test
+  # alone cannot tell "this repo has not adopted the skill" from "the request
+  # failed". Those two must stay distinguishable: the first is the expected state
+  # before adoption, the second is an error that would otherwise silently shrink
+  # the sample an A/B is computed over.
+  local kind="$1" entry="$2" ledger="$3" branch="$4" out="$5"
+  local ref="" rc=0 err=""
+  : >"$out" || return 4
+  if [ "$kind" = local ]; then
+    [ -f "$entry/$ledger" ] || return 3
+    cat "$entry/$ledger" >"$out" || return 4
+    [ -s "$out" ] || return 3
+    return 0
+  fi
+  [ -n "$branch" ] && ref="?ref=$branch"
+  err="$(gh api "repos/$entry/contents/$ledger$ref" \
+           -H "Accept: application/vnd.github.raw" 2>&1 >"$out")" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    case "$err" in
+      *404*) return 3 ;;
+    esac
+    printf 'WARN %s: gh api failed (exit %s): %s\n' "$entry" "$rc" \
+      "$(printf '%s' "$err" | tr -d '\n')" >&2
+    return 4
+  fi
+  [ -s "$out" ] || return 3
+  return 0
 }

--- a/skills/curating-context/scripts/cohort-report.sh
+++ b/skills/curating-context/scripts/cohort-report.sh
@@ -218,14 +218,18 @@ for key in order:
             "best_actions": None, "best_delta": None,
         })
         continue
+    # PRIMARY POLICY FILE: the one measured most recently. A ledger may track
+    # more than one (record-telemetry.sh keys its own deltas by file), and mixing
+    # them makes `net` span two files and report a change for one that never
+    # moved — the class of error the method-change anchoring exists to prevent.
+    #
+    # THIS RULE IS SHARED WITH score-cohort.sh AND MUST STAY IDENTICAL. When the
+    # two disagreed, one ledger produced two irreconcilable pictures of the same
+    # repo: the gate scored a 100-token prune on a secondary file while this
+    # reported the 43,000-token curation on the primary one. A test pins them.
+    #
+    # `runs` counts runs for this file, which is also the more useful number.
     latest = rows[-1]
-    # Everything below is about ONE policy file — the one measured most recently.
-    # A ledger may track more than one (record-telemetry.sh computes its own
-    # deltas per file), and mixing them makes `net` span two different files and
-    # report a change for a file that never moved. That is the same class of
-    # error the method-change anchoring exists to prevent, so it gets the same
-    # treatment. `runs` counts runs for this file, which is also the more useful
-    # number.
     rows = [r for r in rows if r.get("file") == latest.get("file")]
     # The best single reduction and what accompanied it — the roll-up's reason
     # for existing: which optimisation actually moved the number, per repo.

--- a/skills/curating-context/scripts/cohort-report.sh
+++ b/skills/curating-context/scripts/cohort-report.sh
@@ -145,22 +145,26 @@ for want in local repo; do
   while IFS="$CTX_US" read -r kind entry wave pair; do
     [ "$kind" = "$want" ] || continue
     # A ledger's own `repo` field is the basename recorded at write time, which
-    # drifts if a checkout is renamed. Stamp the roster's name on instead — and
+    # drifts if a checkout is renamed. Stamp the roster entry on instead — and
     # the wave and pair with it, so the arm a repo belongs to is visible in the
     # roll-up rather than only inside the gate.
-    name="$(basename "$entry")"
+    #
+    # The FULL entry, not its basename: two entries sharing one (OrgA/cli and
+    # OrgB/cli, or two checkouts of the same project) would merge into a single
+    # record whose rows come from both ledgers. The reader shortens it for
+    # display when no other entry shares the basename.
     RC=0
     ctx_fetch_ledger "$kind" "$entry" "$LEDGER" "$BRANCH" "$TMP/raw" || RC=$?
     case "$RC" in
-      3) printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "MISSING" >>"$TMP/all.jsonl"
+      3) printf '%s\t%s\t%s\t%s\n' "$entry" "$wave" "$pair" "MISSING" >>"$TMP/all.jsonl"
          continue ;;
       0) ;;
-      *) printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "ERROR" >>"$TMP/all.jsonl"
+      *) printf '%s\t%s\t%s\t%s\n' "$entry" "$wave" "$pair" "ERROR" >>"$TMP/all.jsonl"
          continue ;;
     esac
     while IFS= read -r line; do
       [ -n "$line" ] || continue
-      printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "$line" >>"$TMP/all.jsonl"
+      printf '%s\t%s\t%s\t%s\n' "$entry" "$wave" "$pair" "$line" >>"$TMP/all.jsonl"
     done <"$TMP/raw"
   done <"$TMP/roster"
 done
@@ -177,21 +181,33 @@ for raw in open(src, encoding="utf-8"):
     raw = raw.rstrip("\n")
     if not raw or raw.count("\t") < 3:
         continue
-    name, wave, pair, payload = raw.split("\t", 3)
-    if name not in repos:
-        repos[name] = {"rows": [], "status": "ok", "wave": wave, "pair": pair}
-        order.append(name)
+    key, wave, pair, payload = raw.split("\t", 3)
+    if key not in repos:
+        repos[key] = {"rows": [], "status": "ok", "wave": wave, "pair": pair}
+        order.append(key)
     if payload in ("MISSING", "ERROR"):
-        repos[name]["status"] = "no ledger" if payload == "MISSING" else "unreadable"
+        repos[key]["status"] = "no ledger" if payload == "MISSING" else "unreadable"
         continue
     try:
-        repos[name]["rows"].append(json.loads(payload))
+        repos[key]["rows"].append(json.loads(payload))
     except ValueError:
-        repos[name]["status"] = "malformed rows"
+        repos[key]["status"] = "malformed rows"
+
+# Short display names, unless two roster entries share a basename — in which
+# case both are shown in full. A table naming two different repos identically is
+# worse than a wide one.
+basenames = {}
+for key in order:
+    basenames.setdefault(key.rstrip("/").rsplit("/", 1)[-1], []).append(key)
+display = {
+    key: (short if len(keys) == 1 else key)
+    for short, keys in basenames.items() for key in keys
+}
 
 records = []
-for name in order:
-    info = repos[name]
+for key in order:
+    info = repos[key]
+    name = display[key]
     rows = sorted(info["rows"], key=lambda r: r.get("ts") or "")
     if not rows:
         records.append({
@@ -203,6 +219,14 @@ for name in order:
         })
         continue
     latest = rows[-1]
+    # Everything below is about ONE policy file — the one measured most recently.
+    # A ledger may track more than one (record-telemetry.sh computes its own
+    # deltas per file), and mixing them makes `net` span two different files and
+    # report a change for a file that never moved. That is the same class of
+    # error the method-change anchoring exists to prevent, so it gets the same
+    # treatment. `runs` counts runs for this file, which is also the more useful
+    # number.
+    rows = [r for r in rows if r.get("file") == latest.get("file")]
     # The best single reduction and what accompanied it — the roll-up's reason
     # for existing: which optimisation actually moved the number, per repo.
     best = None

--- a/skills/curating-context/scripts/cohort-report.sh
+++ b/skills/curating-context/scripts/cohort-report.sh
@@ -19,7 +19,9 @@ Options:
   --repos LIST       Space-separated owner/repo slugs, read via gh api.
   --local LIST       Space-separated local repo roots, read from disk.
   --cohort-file PATH File of owner/repo slugs or local paths, one per line;
-                     blank lines and # comments ignored. Default, when no
+                     blank lines and # comments ignored. An entry may carry
+                     `wave:` and `pair:` annotations, which this script reports
+                     and score-cohort.sh acts on. Default, when no
                      --repos/--local is given: .skills/cohort
   --ledger PATH      Ledger path within each repo.
                      Default: .skills/context-metrics.jsonl
@@ -50,7 +52,8 @@ missing telemetry is itself the finding on a weekly cadence.
 Exit codes:
   0  report produced (repos without ledgers are reported, not fatal)
   1  usage error, or no repos resolved
-  2  infrastructure failure (gh missing when required, python3 missing)
+  2  infrastructure failure (gh missing when required, python3 missing,
+     _context-lib.sh missing)
 USAGE
 }
 
@@ -81,6 +84,26 @@ esac
 
 command -v python3 >/dev/null 2>&1 || { echo "ERROR python3 is required" >&2; exit 2; }
 
+# --- shared library -------------------------------------------------------
+# After argument parsing, deliberately: the roster parser and the ledger fetch
+# are shared with score-cohort.sh so the two cannot disagree about which repo is
+# in which arm of the experiment.
+_self="${BASH_SOURCE[0]}"
+_n=0
+while [ -L "$_self" ] && [ "$_n" -lt 10 ]; do
+  _t="$(readlink "$_self" 2>/dev/null)" || break
+  case "$_t" in
+    /*) _self="$_t" ;;
+    *) _self="$(dirname "$_self")/$_t" ;;
+  esac
+  _n=$(( _n + 1 ))
+done
+_libdir="$(cd "$(dirname "$_self")" 2>/dev/null && pwd -P)" || _libdir=""
+[ -n "$_libdir" ] && [ -f "$_libdir/_context-lib.sh" ] || {
+  echo "ERROR _context-lib.sh not found next to $_self" >&2; exit 2; }
+# shellcheck source=_context-lib.sh
+. "$_libdir/_context-lib.sh"
+
 TMP="$(mktemp -d)" || { echo "ERROR mktemp failed" >&2; exit 2; }
 trap 'rm -rf "$TMP"' EXIT
 
@@ -88,79 +111,59 @@ trap 'rm -rf "$TMP"' EXIT
 if [ -z "$REPOS" ] && [ -z "$LOCALS" ] && [ -z "$COHORT_FILE" ]; then
   COHORT_FILE=".skills/cohort"
 fi
+: >"$TMP/roster"
+for d in $LOCALS; do
+  printf 'local%s%s%s%s\n' "$CTX_US" "$d" "$CTX_US" "$CTX_US" >>"$TMP/roster"
+done
+for s in $REPOS; do
+  printf 'repo%s%s%s%s\n' "$CTX_US" "$s" "$CTX_US" "$CTX_US" >>"$TMP/roster"
+done
 if [ -n "$COHORT_FILE" ]; then
   if [ ! -f "$COHORT_FILE" ]; then
     echo "ERROR no cohort file at $COHORT_FILE (pass --repos or --local instead)" >&2
     exit 1
   fi
-  while IFS= read -r entry; do
-    entry="${entry%%#*}"
-    entry="$(printf '%s' "$entry" | tr -d '[:space:]')"
-    [ -n "$entry" ] || continue
-    case "$entry" in
-      /*|.*|~*) LOCALS="$LOCALS $entry" ;;
-      *) REPOS="$REPOS $entry" ;;
-    esac
-  done <"$COHORT_FILE"
+  ctx_read_roster "$COHORT_FILE" >>"$TMP/roster"
 fi
 
-if [ -z "$REPOS$LOCALS" ]; then
+if [ ! -s "$TMP/roster" ]; then
   echo "ERROR no repos resolved" >&2
   exit 1
 fi
 
+if grep -q "^repo$CTX_US" "$TMP/roster" && ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR gh is required to read owner/repo entries (use --local for on-disk repos)" >&2
+  exit 2
+fi
+
 : >"$TMP/all.jsonl"
 
-# Local ledgers first — no network, so a partial network failure still yields
-# whatever is on disk.
-for d in $LOCALS; do
-  name="$(basename "$d")"
-  if [ -f "$d/$LEDGER" ]; then
-    # Stamp the source repo onto each row: a ledger's own `repo` field is the
-    # basename recorded at write time, which drifts if a checkout is renamed.
+# Local entries first — no network, so a partial network failure still yields
+# whatever is on disk. Two passes rather than one, because a roster file
+# interleaves the two kinds in whatever order its author wrote them.
+for want in local repo; do
+  while IFS="$CTX_US" read -r kind entry wave pair; do
+    [ "$kind" = "$want" ] || continue
+    # A ledger's own `repo` field is the basename recorded at write time, which
+    # drifts if a checkout is renamed. Stamp the roster's name on instead — and
+    # the wave and pair with it, so the arm a repo belongs to is visible in the
+    # roll-up rather than only inside the gate.
+    name="$(basename "$entry")"
+    RC=0
+    ctx_fetch_ledger "$kind" "$entry" "$LEDGER" "$BRANCH" "$TMP/raw" || RC=$?
+    case "$RC" in
+      3) printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "MISSING" >>"$TMP/all.jsonl"
+         continue ;;
+      0) ;;
+      *) printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "ERROR" >>"$TMP/all.jsonl"
+         continue ;;
+    esac
     while IFS= read -r line; do
       [ -n "$line" ] || continue
-      printf '%s\t%s\n' "$name" "$line" >>"$TMP/all.jsonl"
-    done <"$d/$LEDGER"
-  else
-    printf '%s\t%s\n' "$name" "MISSING" >>"$TMP/all.jsonl"
-  fi
-done
-
-if [ -n "$REPOS" ]; then
-  if ! command -v gh >/dev/null 2>&1; then
-    echo "ERROR gh is required for --repos (use --local for on-disk repos)" >&2
-    exit 2
-  fi
-  for slug in $REPOS; do
-    name="${slug##*/}"
-    ref=""
-    [ -n "$BRANCH" ] && ref="?ref=$BRANCH"
-    # gh api prints nothing AND exits non-zero on 404, so an empty-output test
-    # alone cannot tell "absent" from "empty". Capture both and grep the body
-    # for a 404 marker before deciding.
-    GH_RC=0
-    gh api "repos/$slug/contents/$LEDGER$ref" -H "Accept: application/vnd.github.raw" \
-      >"$TMP/raw" 2>"$TMP/gh.err" || GH_RC=$?
-    if [ "$GH_RC" -ne 0 ]; then
-      if grep -q '404' "$TMP/gh.err"; then
-        printf '%s\t%s\n' "$name" "MISSING" >>"$TMP/all.jsonl"
-      else
-        echo "WARN $slug: gh api failed (exit $GH_RC): $(tr -d '\n' <"$TMP/gh.err")" >&2
-        printf '%s\t%s\n' "$name" "ERROR" >>"$TMP/all.jsonl"
-      fi
-      continue
-    fi
-    if [ ! -s "$TMP/raw" ]; then
-      printf '%s\t%s\n' "$name" "MISSING" >>"$TMP/all.jsonl"
-      continue
-    fi
-    while IFS= read -r line; do
-      [ -n "$line" ] || continue
-      printf '%s\t%s\n' "$name" "$line" >>"$TMP/all.jsonl"
+      printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "$line" >>"$TMP/all.jsonl"
     done <"$TMP/raw"
-  done
-fi
+  done <"$TMP/roster"
+done
 
 python3 - "$TMP/all.jsonl" "$FORMAT" <<'PY'
 import json
@@ -172,11 +175,11 @@ repos = {}
 order = []
 for raw in open(src, encoding="utf-8"):
     raw = raw.rstrip("\n")
-    if not raw or "\t" not in raw:
+    if not raw or raw.count("\t") < 3:
         continue
-    name, payload = raw.split("\t", 1)
+    name, wave, pair, payload = raw.split("\t", 3)
     if name not in repos:
-        repos[name] = {"rows": [], "status": "ok"}
+        repos[name] = {"rows": [], "status": "ok", "wave": wave, "pair": pair}
         order.append(name)
     if payload in ("MISSING", "ERROR"):
         repos[name]["status"] = "no ledger" if payload == "MISSING" else "unreadable"
@@ -195,6 +198,7 @@ for name in order:
             "repo": name, "status": info["status"], "latest": None, "tokens": None,
             "net": None, "net_from": None, "net_why": None, "runs": 0,
             "orphans": None, "dead": None, "skill_version": None,
+            "wave": info["wave"] or None, "pair": info["pair"] or None,
             "best_actions": None, "best_delta": None,
         })
         continue
@@ -245,6 +249,8 @@ for name in order:
         "orphans": latest.get("docs_orphaned"),
         "dead": latest.get("links_dead"),
         "skill_version": latest.get("skill_version"),
+        "wave": info["wave"] or None,
+        "pair": info["pair"] or None,
         "best_actions": ", ".join(best.get("actions") or []) or "(untagged)" if best else None,
         "best_delta": best.get("delta_tokens") if best else None,
     })
@@ -257,11 +263,12 @@ records.sort(key=lambda r: -(r["tokens"] or 0))
 
 if fmt == "tsv":
     print("repo\tlatest\ttokens\tnet\tnet_from\tnet_why\truns\torphans\tdead"
-          "\tskill_version\tbest_delta\tbest_actions")
+          "\tskill_version\twave\tpair\tbest_delta\tbest_actions")
     for r in records:
         print("\t".join("" if r[k] is None else str(r[k]) for k in
               ("repo", "latest", "tokens", "net", "net_from", "net_why", "runs",
-               "orphans", "dead", "skill_version", "best_delta", "best_actions")))
+               "orphans", "dead", "skill_version", "wave", "pair", "best_delta",
+               "best_actions")))
     sys.exit(0)
 
 def cell(v, dash="-"):
@@ -307,6 +314,28 @@ if versions:
         print(f"  {v}: {', '.join(sorted(versions[v]))}")
     if len(versions) == 1:
         print("  one version across the cohort — a baseline, not a comparison.")
+
+# The roster's wave assignment, if it carries one. Printed here rather than only
+# inside score-cohort.sh because the split is a property of the cohort, and the
+# roll-up is where someone looks to see what the cohort is doing.
+waves = {}
+for r in records:
+    if r["wave"]:
+        waves.setdefault(r["wave"], []).append(r["repo"])
+if waves:
+    print("\nvalidation split (roster wave assignment):")
+    for wv in sorted(waves):
+        arm = sorted(waves[wv])
+        adopted = sorted(
+            r["repo"] for r in records
+            if r["wave"] == wv and r["skill_version"]
+        )
+        print(f"  wave {wv}: {len(arm)} repos, {len(adopted)} adopted"
+              f"{' — ' + ', '.join(adopted) if adopted else ''}")
+    unassigned = [r["repo"] for r in records if not r["wave"]]
+    if unassigned:
+        print(f"  unassigned: {', '.join(sorted(unassigned))}")
+    print("  score the arms against each other with score-cohort.sh.")
 untagged = [r["repo"] for r in records if r["runs"] and not r["skill_version"]]
 if untagged:
     print(f"\nno skill_version recorded (rows predate the field): {', '.join(untagged)}")

--- a/skills/curating-context/scripts/cohort-report.sh
+++ b/skills/curating-context/scripts/cohort-report.sh
@@ -218,10 +218,17 @@ for key in order:
             "best_actions": None, "best_delta": None,
         })
         continue
-    # PRIMARY POLICY FILE: the one measured most recently. A ledger may track
-    # more than one (record-telemetry.sh keys its own deltas by file), and mixing
-    # them makes `net` span two files and report a change for one that never
-    # moved — the class of error the method-change anchoring exists to prevent.
+    # PRIMARY POLICY FILE: the one with the most rows, ties broken by whichever
+    # was measured most recently. A ledger may track more than one
+    # (record-telemetry.sh keys its own deltas by file), and mixing them makes
+    # `net` span two files and report a change for one that never moved — the
+    # class of error the method-change anchoring exists to prevent.
+    #
+    # Most-recent alone was the first rule and it was too fragile: one incidental
+    # baseline row for docs/GUIDE.md collapsed a repo that had curated AGENTS.md
+    # 50,000 -> 6,800 to a headline of 4,000 tokens, 1 run and no net — and that
+    # 4,000 then fed the cohort total. Row count is what a stray append cannot
+    # flip.
     #
     # THIS RULE IS SHARED WITH score-cohort.sh AND MUST STAY IDENTICAL. When the
     # two disagreed, one ledger produced two irreconcilable pictures of the same
@@ -229,8 +236,14 @@ for key in order:
     # reported the 43,000-token curation on the primary one. A test pins them.
     #
     # `runs` counts runs for this file, which is also the more useful number.
+    counts, last_seen = {}, {}
+    for i, r in enumerate(rows):
+        f = r.get("file")
+        counts[f] = counts.get(f, 0) + 1
+        last_seen[f] = i           # rows is ascending by ts, so later index wins
+    primary = max(counts, key=lambda f: (counts[f], last_seen[f]))
+    rows = [r for r in rows if r.get("file") == primary]
     latest = rows[-1]
-    rows = [r for r in rows if r.get("file") == latest.get("file")]
     # The best single reduction and what accompanied it — the roll-up's reason
     # for existing: which optimisation actually moved the number, per repo.
     best = None

--- a/skills/curating-context/scripts/record-telemetry.sh
+++ b/skills/curating-context/scripts/record-telemetry.sh
@@ -21,6 +21,12 @@ Options:
                    Recorded verbatim so a later run can correlate a token
                    delta with what produced it.
   --note TEXT      Free-text note for this row (one line).
+  --no-loss V      Record prove-no-loss.sh's verdict for this run: ok, failed,
+                   or skipped. Omitted means "not run", recorded as null.
+                   This is a SAFETY field, not a score: a validation gate reads
+                   it to reject a skill change that reduced tokens by dropping
+                   content, which no token count can distinguish from a good
+                   run. A null is treated as unscorable, never as ok.
   --allow-method-change
                    Append even when this row's measurement method differs from
                    the ledger's latest row for the same file. Refused by default:
@@ -49,6 +55,7 @@ Row schema (one JSON object per line):
   docs_total        live reference docs measured
   docs_orphaned     live docs not reachable from the policy file
   links_dead        broken relative links in the curated surface
+  no_loss           prove-no-loss.sh's verdict, from --no-loss; null if not run
   top_section       largest section title, and its share of the file
   delta_tokens      change vs the previous row for this file. Null on the first
                     row, and null when the measurement method changed since the
@@ -70,6 +77,7 @@ USAGE
 LEDGER=".skills/context-metrics.jsonl"
 ACTIONS=""
 NOTE=""
+NO_LOSS=""
 DRY=0
 TREND=0
 ALLOW_METHOD_CHANGE=0
@@ -86,6 +94,7 @@ while [ $# -gt 0 ]; do
     --ledger) LEDGER="${2:?--ledger needs a path}"; shift 2 ;;
     --actions) need_arg "$#" --actions; ACTIONS="$2"; shift 2 ;;
     --note) need_arg "$#" --note; NOTE="$2"; shift 2 ;;
+    --no-loss) NO_LOSS="${2:?--no-loss needs ok, failed, or skipped}"; shift 2 ;;
     --allow-method-change) ALLOW_METHOD_CHANGE=1; shift ;;
     --dry-run) DRY=1; shift ;;
     --print-trend) TREND=1; shift ;;
@@ -93,6 +102,15 @@ while [ $# -gt 0 ]; do
     *) echo "ERROR unknown argument: $1" >&2; usage >&2; exit 1 ;;
   esac
 done
+
+# Reject an unrecognised verdict rather than storing it. A gate that reads this
+# field treats anything other than "ok" as not-ok, so a typo would silently be a
+# permanent failure recorded against the run — and a typo the other way ("OK"
+# normalised in by a lenient reader) would be a permanent false pass.
+case "$NO_LOSS" in
+  ''|ok|failed|skipped) ;;
+  *) echo "ERROR --no-loss must be ok, failed, or skipped (got '$NO_LOSS')" >&2; exit 1 ;;
+esac
 
 command -v python3 >/dev/null 2>&1 || { echo "ERROR python3 is required" >&2; exit 2; }
 
@@ -113,12 +131,13 @@ mkdir -p "$(dirname "$LEDGER")" || { echo "ERROR cannot create $(dirname "$LEDGE
 [ -f "$LEDGER" ] || : >"$LEDGER" || { echo "ERROR cannot create $LEDGER" >&2; exit 2; }
 
 RC=0
-python3 - "$TMP/in.json" "$LEDGER" "$TODAY" "$REPO_NAME" "$ACTIONS" "$NOTE" "$DRY" "$TREND" "$ALLOW_METHOD_CHANGE" <<'PY' || RC=$?
+python3 - "$TMP/in.json" "$LEDGER" "$TODAY" "$REPO_NAME" "$ACTIONS" "$NOTE" "$DRY" "$TREND" "$ALLOW_METHOD_CHANGE" "$NO_LOSS" <<'PY' || RC=$?
 import datetime as dt
 import json
 import sys
 
-src, ledger, today, repo, actions, note, dry, trend, allow_method = sys.argv[1:10]
+(src, ledger, today, repo, actions, note, dry, trend, allow_method,
+ no_loss) = sys.argv[1:11]
 
 try:
     m = json.load(open(src, encoding="utf-8"))
@@ -151,6 +170,7 @@ row = {
     "docs_total": totals["files_docs"],
     "docs_orphaned": len(links["orphans"]),
     "links_dead": len(links["dead"]),
+    "no_loss": no_loss or None,
     "top_section": top.get("title"),
     "top_section_share": top.get("share"),
     "delta_tokens": None,

--- a/skills/curating-context/scripts/record-telemetry.sh
+++ b/skills/curating-context/scripts/record-telemetry.sh
@@ -27,6 +27,10 @@ Options:
                    it to reject a skill change that reduced tokens by dropping
                    content, which no token count can distinguish from a good
                    run. A null is treated as unscorable, never as ok.
+                   `skipped` records the decision explicitly and reads better in
+                   a ledger, but the gate treats it exactly like a null: only
+                   `ok` clears the check, and only `failed` is evidence that
+                   anything actually went wrong.
   --allow-method-change
                    Append even when this row's measurement method differs from
                    the ledger's latest row for the same file. Refused by default:

--- a/skills/curating-context/scripts/score-cohort.sh
+++ b/skills/curating-context/scripts/score-cohort.sh
@@ -303,8 +303,8 @@ def score_repo(key, info):
         "repo": display[key], "entry": key, "wave": info["wave"],
         "pair": info["pair"], "status": None, "why": None, "before": None,
         "after": None, "budget": None, "closure": None, "no_loss": None,
-        "skill_version": None, "ts": None, "file": None, "gates": [],
-        "unverified": [],
+        "skill_version": None, "ts": None, "file": None, "other_files": 0,
+        "gates": [], "unverified": [],
     }
     if info["status"] != "ok":
         rec["status"] = "unscorable"
@@ -318,19 +318,31 @@ def score_repo(key, info):
         rec["why"] = "no ledger rows"
         return rec
 
-    # PRIMARY POLICY FILE: the one measured most recently. A ledger may track
-    # several — record-telemetry.sh keys its own deltas by file — so "what did
-    # this repo do" is not answerable until one file is named.
+    # PRIMARY POLICY FILE: the one with the most rows, ties broken by whichever
+    # was measured most recently. A ledger may track several — record-telemetry.sh
+    # keys its own deltas by file — so "what did this repo do" is not answerable
+    # until one file is named.
+    #
+    # Most-recent alone was the first rule and it was too fragile: one incidental
+    # baseline row for docs/GUIDE.md re-defined a repo that had curated AGENTS.md
+    # 50,000 -> 6,800 over three runs, dropping it out of the experiment entirely
+    # and collapsing the roll-up's headline to 4,000 tokens / 1 run / no net.
+    # Row count is what a stray append cannot flip.
     #
     # THIS RULE IS SHARED WITH cohort-report.sh AND MUST STAY IDENTICAL. When the
     # two disagreed, one ledger produced two irreconcilable pictures of the same
     # repo: the gate scored sub/AGENTS.md 9,000 -> 8,900 (a 100-token prune, 3.3%
     # closure) while the roll-up reported AGENTS.md at 7,000, net -43,000. A test
     # pins the two scripts to the same answer.
-    primary = rows[-1].get("file")
-    other_files = {r.get("file") for r in rows} - {primary}
+    counts, last_seen = {}, {}
+    for i, r in enumerate(rows):
+        f = r.get("file")
+        counts[f] = counts.get(f, 0) + 1
+        last_seen[f] = i           # rows is ascending by ts, so later index wins
+    primary = max(counts, key=lambda f: (counts[f], last_seen[f]))
     rows = [r for r in rows if r.get("file") == primary]
     rec["file"] = primary
+    rec["other_files"] = len(counts) - 1
 
     scored = scored_idx = None
     for i, r in enumerate(rows):
@@ -347,8 +359,8 @@ def score_repo(key, info):
         scored, scored_idx = r, i
         break
     if scored is None:
-        extra = (f"; {len(other_files)} other file(s) in this ledger were not "
-                 "scored" if other_files else "")
+        extra = (f"; {rec['other_files']} other file(s) in this ledger were not "
+                 "scored" if rec["other_files"] else "")
         rec["status"] = "unscorable"
         rec["why"] = (f"no attributed curation run for {primary} yet (only "
                       f"baselines, or no skill_version){extra}")
@@ -498,10 +510,34 @@ t_versions, c_versions = sorted(t_by_version), sorted(c_by_version)
 
 
 def version_key(v):
-    """Numeric components as a tuple, so 1.10 sorts ABOVE 1.9. Used only for the
-    inverted-arms warning, never for the verdict: a non-numeric component reads
-    as 0, which is fine for a hint and not fine for a decision."""
+    """Numeric components as a tuple, so 1.10 sorts ABOVE 1.9. Used only to
+    decide whether the arms look inverted, never who wins: a non-numeric
+    component reads as 0, which is fine for refusing to score and not fine for
+    scoring."""
     return tuple(int(p) if p.isdigit() else 0 for p in str(v).split("."))
+
+
+def version_canon(v):
+    """One version, one spelling: 1.2 and 1.2.0 are the same release.
+
+    Deliberately NOT version_key, which is lossy — it maps every non-numeric
+    component to 0, so 2.0-alpha and 2.0-beta would collapse into one version
+    and two genuinely different prereleases would be reported as no experiment
+    at all. This only strips trailing zero components, which is the difference
+    that is always cosmetic.
+    """
+    parts = str(v).strip().split(".")
+    while len(parts) > 1 and parts[-1] in ("0", ""):
+        parts.pop()
+    return ".".join(parts)
+
+
+# Every "is this even an experiment?" test compares CANONICAL versions. Comparing
+# the raw strings let 1.2 and 1.2.0 read as two different versions, and the gate
+# returned ADOPT for a comparison of a release against itself — finding 32's
+# mirror, a positive verdict out of a non-experiment.
+t_canon = {version_canon(v) for v in t_versions}
+c_canon = {version_canon(v) for v in c_versions}
 
 
 # Wave A adopts first and therefore holds the OLDER version, so the first
@@ -521,46 +557,70 @@ inverted = bool(t_versions and c_versions
 # safety failures are still printed in the body whatever the verdict, so nothing
 # is masked by the reordering.
 verdict, code, reasons = None, 0, []
-if inverted:
-    # Detection alone was not enough: the WARN printed at the top and the verdict
-    # then rejected the winning change and told the reader to file it as refuted,
-    # twenty lines below the warning saying not to trust the result.
-    verdict, code = "INCONCLUSIVE", 5
-    reasons.append(f"the arms look inverted — wave {treatment} carries only "
-                   f"older versions ({', '.join(t_versions)}) than wave "
-                   f"{control} ({', '.join(c_versions)}). Re-run with "
-                   f"--treatment {control} --control {treatment}; as scored "
-                   "here a winning change reads as a losing one")
-elif not t_versions:
+inversion_is_the_verdict = False
+if not t_versions:
     verdict, code = "INCONCLUSIVE", 5
     reasons.append(f"no attributed curation run in the treatment arm (wave "
                    f"{treatment}) yet — nothing has been measured to compare")
-elif len(t_versions) > 1 or len(c_versions) > 1:
+elif not c_versions:
+    # The symmetric case, and the EXPECTED intermediate state during the first
+    # experiment: wave B adopts the proposal before wave A has re-run. Without
+    # this branch it fell through to "no informative pairs", which is true and
+    # sends the reader to look at pair scoring instead of at adoption progress.
+    verdict, code = "INCONCLUSIVE", 5
+    reasons.append(f"no attributed curation run in the control arm (wave "
+                   f"{control}) yet — the treatment has nothing to be compared "
+                   "against. Expected while the arms are still catching up")
+elif len(t_canon) > 1 or len(c_canon) > 1:
     # "Adopt only if strictly better" presumes ONE proposal. An arm split across
     # versions names no coherent change, and a sweep could be carried by
     # whichever version happened to draw the easier pairs.
+    #
+    # Ahead of the inverted-arms test on purpose: an arm that is not internally
+    # coherent cannot meaningfully be called older or newer than the other, and
+    # reporting inversion first walked the reader through two diagnoses — swap
+    # the flags, hit the split — to reach one problem.
     verdict, code = "INCONCLUSIVE", 5
-    split = t_by_version if len(t_versions) > 1 else c_by_version
-    which = treatment if len(t_versions) > 1 else control
+    split = t_by_version if len(t_canon) > 1 else c_by_version
+    which = treatment if len(t_canon) > 1 else control
     reasons.append(
         f"wave {which} is split across versions, so there is no single change to "
         "adopt: "
         + "; ".join(f"{v} ({', '.join(sorted(split[v]))})" for v in sorted(split))
         + " — bring the arm onto one version and re-score")
-elif t_versions == c_versions:
+elif t_canon == c_canon:
     verdict, code = "INCONCLUSIVE", 5
-    reasons.append(f"both arms ran the same version ({', '.join(t_versions)}); "
-                   "this is a baseline, not a comparison")
+    spelling = ""
+    if set(t_versions) != set(c_versions):
+        spelling = (f" — recorded as {', '.join(t_versions)} and "
+                    f"{', '.join(c_versions)}, which canonicalise to the same "
+                    "release; worth making the spelling uniform")
+    reasons.append(f"both arms ran the same version ({', '.join(sorted(t_canon))})"
+                   f"{spelling}; this is a baseline, not a comparison")
     if t_failures:
         # Real, and worth acting on, but it is a finding about the shipped
         # version rather than grounds to reject a proposal that does not exist.
         reasons.append("a safety gate did trip under that version — see the "
                        "treatment-arm failures above; that is a finding about "
                        "what is shipped, not a rejection of anything proposed")
+elif inverted:
+    # Detection alone was not enough: the WARN printed at the top and the verdict
+    # then rejected the winning change and told the reader to file it as refuted,
+    # twenty lines below the warning saying not to trust the result.
+    inversion_is_the_verdict = True
+    verdict, code = "INCONCLUSIVE", 5
+    reasons.append(f"the arms look inverted — wave {treatment} carries only "
+                   f"older versions ({', '.join(t_versions)}) than wave "
+                   f"{control} ({', '.join(c_versions)}). Re-run with "
+                   f"--treatment {control} --control {treatment}; as scored "
+                   "here a winning change reads as a losing one")
 elif t_failures:
     verdict, code = "REJECT", 3
-    reasons.append("a safety gate tripped in the treatment arm: "
-                   + "; ".join(f"{r['repo']} ({r['why']})" for r in t_failures))
+    # Named in the body rather than enumerated twice. The body block is what
+    # keeps failures visible under the INCONCLUSIVE paths above, so it must not
+    # look redundant enough to delete.
+    reasons.append("a safety gate tripped in the treatment arm — see the "
+                   "treatment-arm failures above")
 elif t_unverified:
     # Blocks adoption, like a failure, but is NOT a rejection: nothing was
     # refuted, the experiment was run without its safety check. Filing that in
@@ -598,13 +658,16 @@ else:
     reasons.append(f"the treatment won {len(wins)} of {len(informative)} "
                    f"informative pairs; adoption requires all ({'; '.join(lost)})")
 
+# Only when inversion is what actually stopped the run. A split arm also trips
+# the older-than test — an incoherent arm compares older than anything — and
+# printing both banners walks the reader through two diagnoses for one problem.
 inversion_warning = (
     f"WARN wave {treatment} carries only older versions than wave {control} "
     f"({', '.join(t_versions)} vs {', '.join(c_versions)}). The arms look "
     f"inverted: wave A adopts first and holds the older version, so the first "
     f"experiment runs --treatment {control} --control {treatment}. As scored "
     f"here, a winning change reads as a losing one."
-) if inverted else None
+) if inversion_is_the_verdict else None
 
 if fmt == "json":
     print(json.dumps({
@@ -655,6 +718,18 @@ for p in pairs:
     else:
         print(f"{'':>4}  -> uninformative: {p['why']}")
 print()
+
+# Which file each score is actually about. The table has no room for a column,
+# and without this a multi-file ledger reads as though its whole history were in
+# view — two repos showing 50,000 -> 7,000 with no sign that a prune on a
+# secondary file was excluded from both.
+multi = [r for r in records if r["other_files"]]
+if multi:
+    print("multi-file ledgers — the file scored, and how many were not:")
+    for r in multi:
+        print(f"  {r['repo']}: {r['file']} "
+              f"(+{r['other_files']} other file(s) not scored)")
+    print()
 
 unassigned = [r for r in records if not r["pair"]]
 if unassigned:

--- a/skills/curating-context/scripts/score-cohort.sh
+++ b/skills/curating-context/scripts/score-cohort.sh
@@ -31,7 +31,7 @@ Options:
                       Default: .skills/context-metrics.jsonl
   --branch NAME       Branch to read for owner/repo entries.
   --min-pairs N       Fewest informative pairs that can produce a verdict
-                      other than INCONCLUSIVE. Default: 3
+                      other than INCONCLUSIVE. Minimum 1. Default: 3
   --format FMT        table (default) or json
   -h, --help          Show this help and exit 0.
 
@@ -41,6 +41,10 @@ What it scores
   `baseline*`. First runs are what get compared, because a repo's first curation
   and its fifth are not the same task, and the roster's pairs are matched on
   starting state precisely so that first-against-first is a fair comparison.
+
+  The before-state is the previous row FOR THE SAME POLICY FILE. A ledger may
+  track several, and an untagged run (actions: []) cannot be told from a
+  baseline, so it makes the repo unscorable rather than being guessed at.
 
   The effectiveness metric is budget-gap closure:
 
@@ -62,12 +66,19 @@ Safety gates (checked before any score)
 
   Any tripped gate in the treatment arm is an outright REJECT, whatever the token
   numbers say — a change that reduces tokens by losing content is the one failure
-  this skill exists to prevent, and no amount of closure buys it back. Missing
-  data is never a pass: a run with no `no_loss` field is unscorable, not ok.
+  this skill exists to prevent, and no amount of closure buys it back.
+
+  A RECORDED failure and a MISSING verdict are kept apart. Both block adoption;
+  only the first is evidence anything went wrong. A `no_loss` that is absent or
+  `skipped` yields INCONCLUSIVE, not REJECT — nothing was refuted, the experiment
+  was run without its safety check, and filing that in rejected-changes.md would
+  record the idea as tested and beaten when it was neither.
 
   A tripped gate in the CONTROL arm is reported but does not reject: that is the
   current version failing, which is a finding about today rather than a reason to
-  refuse tomorrow.
+  refuse tomorrow. A missing verdict there is reported separately again, because
+  "failure" would read as the shipped skill having dropped content when in fact
+  nobody ran the check.
 
 Adoption rule
   Adopt only if the treatment wins EVERY informative pair. Ties, mixed results,
@@ -82,8 +93,9 @@ Exit codes:
   0  ADOPT — treatment won every informative pair, no safety gate tripped
   1  usage error, or the roster carries no wave assignment
   2  infrastructure failure (python3 or gh missing, library missing)
-  3  REJECT — a safety gate tripped, or the treatment did not sweep
-  5  INCONCLUSIVE — too few informative pairs, or both arms ran the same version
+  3  REJECT — a recorded safety gate tripped, or the treatment did not sweep
+  5  INCONCLUSIVE — nothing was decided: too few informative pairs, safety
+     unverified, both arms on one version, or an arm split across versions
 USAGE
 }
 
@@ -114,8 +126,14 @@ case "$FORMAT" in
   *) echo "ERROR --format must be table or json" >&2; exit 1 ;;
 esac
 case "$MIN_PAIRS" in
-  ''|*[!0-9]*) echo "ERROR --min-pairs must be a non-negative integer" >&2; exit 1 ;;
+  ''|*[!0-9]*) echo "ERROR --min-pairs must be a positive integer" >&2; exit 1 ;;
 esac
+# Zero is refused rather than clamped. A verdict computed over no pairs is not a
+# weaker verdict, it is no verdict, and the sweep test reads `0 == 0` as a win.
+[ "$MIN_PAIRS" -ge 1 ] || {
+  echo "ERROR --min-pairs must be at least 1: a comparison over zero pairs" >&2
+  echo "      would adopt on no evidence at all" >&2
+  exit 1; }
 if [ "$TREATMENT" = "$CONTROL" ]; then
   echo "ERROR --treatment and --control name the same wave ('$TREATMENT')" >&2
   exit 1
@@ -124,8 +142,10 @@ fi
 command -v python3 >/dev/null 2>&1 || { echo "ERROR python3 is required" >&2; exit 2; }
 
 # --- shared library -------------------------------------------------------
-# After argument parsing: the library defines no `usage`, but the four sibling
-# scripts all source here and matching them keeps the shape reviewable.
+# After argument parsing, matching the five sibling scripts. The library
+# namespaces its own help as ctx_lib_usage() precisely so that sourcing cannot
+# replace a caller's usage() — before that rename it did, and only the
+# convention of parsing arguments first kept anyone's --help working.
 _self="${BASH_SOURCE[0]}"
 _n=0
 while [ -L "$_self" ] && [ "$_n" -lt 10 ]; do
@@ -183,19 +203,21 @@ while IFS="$CTX_US" read -r kind entry wave pair; do
     "$TREATMENT"|"$CONTROL") ;;
     *) continue ;;
   esac
-  name="$(basename "$entry")"
+  # The FULL roster entry is the key, not its basename: OrgA/cli and OrgB/cli
+  # would otherwise merge into one record. The reader shortens it for display
+  # when it is unambiguous.
   RC=0
   ctx_fetch_ledger "$kind" "$entry" "$LEDGER" "$BRANCH" "$TMP/raw" || RC=$?
   case "$RC" in
-    3) printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "MISSING" >>"$TMP/all.jsonl"
+    3) printf '%s\t%s\t%s\t%s\n' "$entry" "$wave" "$pair" "MISSING" >>"$TMP/all.jsonl"
        continue ;;
     0) ;;
-    *) printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "ERROR" >>"$TMP/all.jsonl"
+    *) printf '%s\t%s\t%s\t%s\n' "$entry" "$wave" "$pair" "ERROR" >>"$TMP/all.jsonl"
        continue ;;
   esac
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "$line" >>"$TMP/all.jsonl"
+    printf '%s\t%s\t%s\t%s\n' "$entry" "$wave" "$pair" "$line" >>"$TMP/all.jsonl"
   done <"$TMP/raw"
 done <"$TMP/roster"
 
@@ -213,32 +235,55 @@ for raw in open(src, encoding="utf-8"):
     raw = raw.rstrip("\n")
     if not raw or raw.count("\t") < 3:
         continue
-    name, wave, pair, payload = raw.split("\t", 3)
-    if name not in repos:
-        repos[name] = {"rows": [], "status": "ok", "wave": wave, "pair": pair}
-        order.append(name)
+    key, wave, pair, payload = raw.split("\t", 3)
+    if key not in repos:
+        repos[key] = {"rows": [], "status": "ok", "wave": wave, "pair": pair}
+        order.append(key)
     if payload in ("MISSING", "ERROR"):
-        repos[name]["status"] = "no ledger" if payload == "MISSING" else "unreadable"
+        repos[key]["status"] = "no ledger" if payload == "MISSING" else "unreadable"
         continue
     try:
-        repos[name]["rows"].append(json.loads(payload))
+        repos[key]["rows"].append(json.loads(payload))
     except ValueError:
-        repos[name]["status"] = "malformed rows"
+        repos[key]["status"] = "malformed rows"
+
+# Repos are keyed by their full roster entry, not by basename: two entries
+# sharing a basename (OrgA/cli and OrgB/cli, or two local checkouts of the same
+# project) would otherwise merge into one record, concatenating two ledgers and
+# reporting one arm as having no attributed run when it has one. The display
+# name stays short unless it would be ambiguous, in which case the whole entry
+# is shown — a table row that names two different repos identically is worse
+# than a wide one.
+basenames = {}
+for key in order:
+    basenames.setdefault(key.rstrip("/").rsplit("/", 1)[-1], []).append(key)
+display = {
+    key: (short if len(keys) == 1 else key)
+    for short, keys in basenames.items() for key in keys
+}
 
 
-def is_baseline(row):
-    """A measurement, not a curation. Baseline rows establish the starting
-    number and must not be scored as though the skill had done work."""
+def classify_run(row):
+    """Which kind of run a ledger row records: a baseline measurement, a
+    curation, or something that cannot be told apart from either."""
     acts = row.get("actions") or []
-    return bool(acts) and all(a.split(":", 1)[0] == "baseline" for a in acts)
+    if not acts:
+        # record-telemetry.sh emits actions: [] when --actions was omitted. An
+        # untagged run cannot be distinguished from a baseline, and scoring one
+        # as a curation would attribute its near-zero closure to the skill
+        # version. Surface the tagging gap instead of guessing past it.
+        return "untagged"
+    if all(a.split(":", 1)[0] == "baseline" for a in acts):
+        return "baseline"
+    return "curation"
 
 
-def score_repo(name, info):
+def score_repo(key, info):
     rec = {
-        "repo": name, "wave": info["wave"], "pair": info["pair"],
-        "status": None, "why": None, "before": None, "after": None,
-        "budget": None, "closure": None, "no_loss": None,
-        "skill_version": None, "ts": None, "gates": [],
+        "repo": display[key], "entry": key, "wave": info["wave"],
+        "pair": info["pair"], "status": None, "why": None, "before": None,
+        "after": None, "budget": None, "closure": None, "no_loss": None,
+        "skill_version": None, "ts": None, "gates": [], "unverified": [],
     }
     if info["status"] != "ok":
         rec["status"] = "unscorable"
@@ -252,16 +297,34 @@ def score_repo(name, info):
         rec["why"] = "no ledger rows"
         return rec
 
-    scored = prev = None
-    for i, r in enumerate(rows):
-        if r.get("skill_version") and not is_baseline(r):
-            scored = r
-            prev = rows[i - 1] if i else None
-            break
+    scored = None
+    for r in rows:
+        if not r.get("skill_version"):
+            continue
+        kind = classify_run(r)
+        if kind == "baseline":
+            continue
+        if kind == "untagged":
+            rec["status"] = "unscorable"
+            rec["why"] = ("the first attributed run carries no action tags, so it "
+                          "cannot be told from a baseline; tag it and re-score")
+            return rec
+        scored = r
+        break
     if scored is None:
         rec["status"] = "unscorable"
         rec["why"] = "no attributed curation run yet (only baselines, or no skill_version)"
         return rec
+
+    # The before-state must come from the SAME policy file. A ledger may track
+    # more than one — record-telemetry.sh computes its own deltas per file — and
+    # taking the row that merely happens to precede this one produced a
+    # fabricated closure: a repo that actually went 50,000 -> 9,000 scored -2900%
+    # off an unrelated file's 6,100.
+    target = scored.get("file")
+    same_file = [r for r in rows if r.get("file") == target]
+    idx = same_file.index(scored)
+    prev = same_file[idx - 1] if idx else None
 
     rec["skill_version"] = scored.get("skill_version")
     rec["ts"] = scored.get("ts")
@@ -272,9 +335,18 @@ def score_repo(name, info):
     # Safety first, and independent of whether the run is scorable for
     # effectiveness: a run that dropped content is a failure even if its
     # before-row is missing and no closure can be computed.
-    if scored.get("no_loss") != "ok":
-        got = scored.get("no_loss") or "not recorded"
-        rec["gates"].append(f"no_loss={got}")
+    #
+    # A recorded non-ok verdict and an absent one are kept apart. Both block
+    # adoption, but only the first is evidence that anything went wrong, and
+    # calling a missing verdict a "failure" in the control-arm report reads as
+    # the shipped skill having dropped content when nobody ran the check.
+    nl = scored.get("no_loss")
+    if nl == "ok":
+        pass
+    elif nl in (None, "skipped"):
+        rec["unverified"].append(f"no_loss={nl or 'not recorded'}")
+    else:
+        rec["gates"].append(f"no_loss={nl}")
     dead = scored.get("links_dead")
     if isinstance(dead, int) and dead > 0:
         rec["gates"].append(f"links_dead={dead}")
@@ -286,6 +358,10 @@ def score_repo(name, info):
     if rec["gates"]:
         rec["status"] = "failed"
         rec["why"] = "; ".join(rec["gates"])
+        return rec
+    if rec["unverified"]:
+        rec["status"] = "unverified"
+        rec["why"] = "; ".join(rec["unverified"])
         return rec
 
     if prev is None:
@@ -314,7 +390,7 @@ def score_repo(name, info):
     return rec
 
 
-records = [score_repo(n, repos[n]) for n in order]
+records = [score_repo(k, repos[k]) for k in order]
 by_arm = {treatment: {}, control: {}}
 for r in records:
     if r["wave"] in by_arm and r["pair"]:
@@ -363,27 +439,86 @@ for pid in sorted(set(by_arm[treatment]) | set(by_arm[control]),
 
 informative = [p for p in pairs if p["informative"]]
 wins = [p for p in informative if p["winner"] == "treatment"]
-t_failures = [r for r in records if r["wave"] == treatment and r["status"] == "failed"]
-c_failures = [r for r in records if r["wave"] == control and r["status"] == "failed"]
 
-t_versions = sorted({r["skill_version"] for r in records
-                     if r["wave"] == treatment and r["skill_version"]})
-c_versions = sorted({r["skill_version"] for r in records
-                     if r["wave"] == control and r["skill_version"]})
+
+def arm(wave, status):
+    return [r for r in records if r["wave"] == wave and r["status"] == status]
+
+
+t_failures = arm(treatment, "failed")
+t_unverified = arm(treatment, "unverified")
+c_failures = arm(control, "failed")
+c_unverified = arm(control, "unverified")
+
+
+def versions_in(wave):
+    m = {}
+    for r in records:
+        if r["wave"] == wave and r["skill_version"]:
+            m.setdefault(r["skill_version"], []).append(r["repo"])
+    return m
+
+
+t_by_version, c_by_version = versions_in(treatment), versions_in(control)
+t_versions, c_versions = sorted(t_by_version), sorted(c_by_version)
+
+
+def version_key(v):
+    """Numeric components as a tuple, so 1.10 sorts ABOVE 1.9. Used only for the
+    inverted-arms warning, never for the verdict: a non-numeric component reads
+    as 0, which is fine for a hint and not fine for a decision."""
+    return tuple(int(p) if p.isdigit() else 0 for p in str(v).split("."))
+
+
+# Wave A adopts first and therefore holds the OLDER version, so the first
+# experiment runs `--treatment b --control a` — and running the script bare
+# inverts it, turning a winning change into a losing one. Detectable, so detect
+# it rather than relying on three places in the docs saying so.
+inverted = bool(t_versions and c_versions
+                and max(map(version_key, t_versions))
+                < min(map(version_key, c_versions)))
 
 verdict, code, reasons = None, 0, []
 if t_failures:
     verdict, code = "REJECT", 3
     reasons.append("a safety gate tripped in the treatment arm: "
                    + "; ".join(f"{r['repo']} ({r['why']})" for r in t_failures))
+elif t_unverified:
+    # Blocks adoption, like a failure, but is NOT a rejection: nothing was
+    # refuted, the experiment was run without its safety check. Filing that in
+    # rejected-changes.md would record the idea as tested and beaten when it was
+    # neither.
+    verdict, code = "INCONCLUSIVE", 5
+    reasons.append("safety could not be verified in the treatment arm: "
+                   + "; ".join(f"{r['repo']} ({r['why']})" for r in t_unverified)
+                   + " — re-run those curations with --no-loss and re-score")
 elif not t_versions:
     verdict, code = "INCONCLUSIVE", 5
     reasons.append(f"no attributed curation run in the treatment arm (wave "
                    f"{treatment}) yet — nothing has been measured to compare")
+elif len(t_versions) > 1 or len(c_versions) > 1:
+    # "Adopt only if strictly better" presumes ONE proposal. An arm split across
+    # versions names no coherent change, and a sweep could be carried by
+    # whichever version happened to draw the easier pairs.
+    verdict, code = "INCONCLUSIVE", 5
+    split = t_by_version if len(t_versions) > 1 else c_by_version
+    which = treatment if len(t_versions) > 1 else control
+    reasons.append(
+        f"wave {which} is split across versions, so there is no single change to "
+        "adopt: "
+        + "; ".join(f"{v} ({', '.join(sorted(split[v]))})" for v in sorted(split))
+        + " — bring the arm onto one version and re-score")
 elif t_versions == c_versions:
     verdict, code = "INCONCLUSIVE", 5
     reasons.append(f"both arms ran the same version ({', '.join(t_versions)}); "
                    "this is a baseline, not a comparison")
+elif not informative:
+    # Independent of --min-pairs. With --min-pairs 0 the sweep test below reads
+    # `0 == 0` and adopts on no evidence whatever — a vacuous pass in the one
+    # control that exists to prevent them.
+    verdict, code = "INCONCLUSIVE", 5
+    reasons.append("no informative pairs — every pair was uninformative, so "
+                   "nothing was measured")
 elif len(informative) < min_pairs:
     verdict, code = "INCONCLUSIVE", 5
     reasons.append(f"{len(informative)} informative pair(s), minimum {min_pairs}")
@@ -405,6 +540,14 @@ else:
     reasons.append(f"the treatment won {len(wins)} of {len(informative)} "
                    f"informative pairs; adoption requires all ({'; '.join(lost)})")
 
+inversion_warning = (
+    f"WARN wave {treatment} carries only older versions than wave {control} "
+    f"({', '.join(t_versions)} vs {', '.join(c_versions)}). The arms look "
+    f"inverted: wave A adopts first and holds the older version, so the first "
+    f"experiment runs --treatment {control} --control {treatment}. As scored "
+    f"here, a winning change reads as a losing one."
+) if inverted else None
+
 if fmt == "json":
     print(json.dumps({
         "treatment_wave": treatment, "control_wave": control,
@@ -413,6 +556,8 @@ if fmt == "json":
         "informative_pairs": len(informative), "treatment_wins": len(wins),
         "min_pairs": min_pairs, "verdict": verdict, "reasons": reasons,
         "control_arm_failures": [r["repo"] for r in c_failures],
+        "control_arm_unverified": [r["repo"] for r in c_unverified],
+        "arms_may_be_inverted": inverted,
     }, indent=2))
     sys.exit(code)
 
@@ -428,6 +573,9 @@ def num(v):
 w = max([len(r["repo"]) for r in records] + [4])
 print(f"treatment wave {treatment}: {', '.join(t_versions) or 'no attributed runs'}")
 print(f"control   wave {control}: {', '.join(c_versions) or 'no attributed runs'}")
+if inversion_warning:
+    print()
+    print(inversion_warning)
 print()
 print(f"{'pair':>4}  {'arm':<3} {'repo':<{w}} {'before':>8} {'after':>8} "
       f"{'budget':>7} {'closure':>8}  no_loss")
@@ -455,6 +603,14 @@ if c_failures:
     print("control-arm safety failures (reported, not a reason to reject the "
           "proposal):")
     for r in c_failures:
+        print(f"  {r['repo']}: {r['why']}")
+    print()
+if c_unverified:
+    # Kept out of the block above on purpose. "Failure" there means the current
+    # version did something wrong; this means nobody checked.
+    print("control-arm runs with no safety verdict (not a failure — the check "
+          "was not run):")
+    for r in c_unverified:
         print(f"  {r['repo']}: {r['why']}")
     print()
 

--- a/skills/curating-context/scripts/score-cohort.sh
+++ b/skills/curating-context/scripts/score-cohort.sh
@@ -1,0 +1,474 @@
+#!/usr/bin/env bash
+# score-cohort.sh — decide whether a proposed change to curating-context is
+# adopted, by scoring one arm of the cohort against the other.
+#
+# The cohort is this skill's held-out validation split. Every learning folded in
+# so far was accepted because it seemed right to whoever proposed it; this script
+# exists so that stops being the standard. It reports, it never writes, and it
+# never adopts anything — a human reads the verdict and acts on it.
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+score-cohort.sh — paired validation gate for skill changes
+
+Usage:
+  score-cohort.sh [--cohort-file PATH] [--treatment WAVE] [--control WAVE]
+
+Options:
+  --cohort-file PATH  Roster carrying `wave:` and `pair:` annotations.
+                      Default: .skills/cohort
+  --treatment WAVE    Wave running the PROPOSED version. Default: a
+  --control WAVE      Wave running the CURRENT version. Default: b
+
+                      Note the direction. Wave A adopts FIRST and therefore
+                      holds the OLDER version, so the first experiment inverts
+                      the defaults: --treatment b --control a. The defaults suit
+                      later rounds, once A has caught up and is the arm carrying
+                      a proposal. Get this backwards and a winning change reads
+                      as a losing one.
+  --ledger PATH       Ledger path within each repo.
+                      Default: .skills/context-metrics.jsonl
+  --branch NAME       Branch to read for owner/repo entries.
+  --min-pairs N       Fewest informative pairs that can produce a verdict
+                      other than INCONCLUSIVE. Default: 3
+  --format FMT        table (default) or json
+  -h, --help          Show this help and exit 0.
+
+What it scores
+  For each repo, the FIRST curation run recorded under a skill version — the
+  first ledger row carrying `skill_version` whose actions are not purely
+  `baseline*`. First runs are what get compared, because a repo's first curation
+  and its fifth are not the same task, and the roster's pairs are matched on
+  starting state precisely so that first-against-first is a fair comparison.
+
+  The effectiveness metric is budget-gap closure:
+
+      gap     = max(0, tokens - budget)
+      closure = (gap_before - gap_after) / gap_before
+
+  A fraction, not a token count, because the cohort spans 5,331 to 52,953 tokens
+  and an absolute reduction would let the largest repo decide every verdict.
+  A repo already under budget has no gap to close; it is scored for safety and
+  reported as uninformative for effectiveness rather than counted as a 0 or a 1.
+
+Safety gates (checked before any score)
+  A treatment run trips a gate if it dropped content, broke the surface, or left
+  it less navigable than it found it:
+
+    no_loss != ok       prove-no-loss.sh did not confirm relocation
+    links_dead > 0      the curated surface has broken links
+    docs_orphaned rose  demotion created docs nothing points at
+
+  Any tripped gate in the treatment arm is an outright REJECT, whatever the token
+  numbers say — a change that reduces tokens by losing content is the one failure
+  this skill exists to prevent, and no amount of closure buys it back. Missing
+  data is never a pass: a run with no `no_loss` field is unscorable, not ok.
+
+  A tripped gate in the CONTROL arm is reported but does not reject: that is the
+  current version failing, which is a finding about today rather than a reason to
+  refuse tomorrow.
+
+Adoption rule
+  Adopt only if the treatment wins EVERY informative pair. Ties, mixed results,
+  and "no measurable difference" are all rejections. With five informative pairs
+  a clean sweep is p=0.031 under a one-sided sign test, and anything short of one
+  is not distinguishable from noise at this sample size — so a majority rule here
+  would be a rule for adopting noise.
+
+  Record every rejection in references/rejected-changes.md with these numbers.
+
+Exit codes:
+  0  ADOPT — treatment won every informative pair, no safety gate tripped
+  1  usage error, or the roster carries no wave assignment
+  2  infrastructure failure (python3 or gh missing, library missing)
+  3  REJECT — a safety gate tripped, or the treatment did not sweep
+  5  INCONCLUSIVE — too few informative pairs, or both arms ran the same version
+USAGE
+}
+
+COHORT_FILE=".skills/cohort"
+TREATMENT="a"
+CONTROL="b"
+LEDGER=".skills/context-metrics.jsonl"
+BRANCH=""
+MIN_PAIRS=3
+FORMAT="table"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cohort-file) COHORT_FILE="${2:?--cohort-file needs a path}"; shift 2 ;;
+    --treatment) TREATMENT="${2:?--treatment needs a wave}"; shift 2 ;;
+    --control) CONTROL="${2:?--control needs a wave}"; shift 2 ;;
+    --ledger) LEDGER="${2:?--ledger needs a path}"; shift 2 ;;
+    --branch) BRANCH="${2:?--branch needs a name}"; shift 2 ;;
+    --min-pairs) MIN_PAIRS="${2:?--min-pairs needs a number}"; shift 2 ;;
+    --format) FORMAT="${2:?--format needs a value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+case "$FORMAT" in
+  table|json) ;;
+  *) echo "ERROR --format must be table or json" >&2; exit 1 ;;
+esac
+case "$MIN_PAIRS" in
+  ''|*[!0-9]*) echo "ERROR --min-pairs must be a non-negative integer" >&2; exit 1 ;;
+esac
+if [ "$TREATMENT" = "$CONTROL" ]; then
+  echo "ERROR --treatment and --control name the same wave ('$TREATMENT')" >&2
+  exit 1
+fi
+
+command -v python3 >/dev/null 2>&1 || { echo "ERROR python3 is required" >&2; exit 2; }
+
+# --- shared library -------------------------------------------------------
+# After argument parsing: the library defines no `usage`, but the four sibling
+# scripts all source here and matching them keeps the shape reviewable.
+_self="${BASH_SOURCE[0]}"
+_n=0
+while [ -L "$_self" ] && [ "$_n" -lt 10 ]; do
+  _t="$(readlink "$_self" 2>/dev/null)" || break
+  case "$_t" in
+    /*) _self="$_t" ;;
+    *) _self="$(dirname "$_self")/$_t" ;;
+  esac
+  _n=$(( _n + 1 ))
+done
+_libdir="$(cd "$(dirname "$_self")" 2>/dev/null && pwd -P)" || _libdir=""
+[ -n "$_libdir" ] && [ -f "$_libdir/_context-lib.sh" ] || {
+  echo "ERROR _context-lib.sh not found next to $_self" >&2; exit 2; }
+# shellcheck source=_context-lib.sh
+. "$_libdir/_context-lib.sh"
+
+TMP="$(mktemp -d)" || { echo "ERROR mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TMP"' EXIT
+
+[ -f "$COHORT_FILE" ] || {
+  echo "ERROR no cohort file at $COHORT_FILE" >&2; exit 1; }
+
+ctx_read_roster "$COHORT_FILE" >"$TMP/roster"
+
+# An unannotated roster cannot answer the question this script asks. Say what is
+# missing and what it looks like, rather than reporting an empty comparison as
+# though the experiment had run and found nothing.
+# The flag, rather than `$3 != "" { exit 0 }`: awk's `exit` runs the END block on
+# its way out, so an END that exits too has the last word and the early exit is
+# discarded. Written the obvious way this reported every annotated roster as
+# unannotated.
+if ! awk -F"$CTX_US" '$3 != "" { found = 1; exit } END { exit !found }' "$TMP/roster"; then
+  cat >&2 <<EOF
+ERROR $COHORT_FILE carries no wave assignment, so there are no arms to compare.
+      Annotate each entry, e.g.:
+
+        CannObserv/usa-wa                      wave:a pair:1
+        CannObserv/cannabis.observer-wordpress wave:b pair:1
+
+      Pairs are matched on starting state; see references/validation-gate.md.
+EOF
+  exit 1
+fi
+
+if awk -F"$CTX_US" '$1 == "repo" { found = 1; exit } END { exit !found }' "$TMP/roster" \
+   && ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR gh is required to read owner/repo entries" >&2
+  exit 2
+fi
+
+: >"$TMP/all.jsonl"
+while IFS="$CTX_US" read -r kind entry wave pair; do
+  [ -n "$wave" ] || continue
+  case "$wave" in
+    "$TREATMENT"|"$CONTROL") ;;
+    *) continue ;;
+  esac
+  name="$(basename "$entry")"
+  RC=0
+  ctx_fetch_ledger "$kind" "$entry" "$LEDGER" "$BRANCH" "$TMP/raw" || RC=$?
+  case "$RC" in
+    3) printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "MISSING" >>"$TMP/all.jsonl"
+       continue ;;
+    0) ;;
+    *) printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "ERROR" >>"$TMP/all.jsonl"
+       continue ;;
+  esac
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    printf '%s\t%s\t%s\t%s\n' "$name" "$wave" "$pair" "$line" >>"$TMP/all.jsonl"
+  done <"$TMP/raw"
+done <"$TMP/roster"
+
+RC=0
+python3 - "$TMP/all.jsonl" "$TREATMENT" "$CONTROL" "$MIN_PAIRS" "$FORMAT" <<'PY' || RC=$?
+import json
+import sys
+
+src, treatment, control, min_pairs, fmt = sys.argv[1:6]
+min_pairs = int(min_pairs)
+
+repos = {}
+order = []
+for raw in open(src, encoding="utf-8"):
+    raw = raw.rstrip("\n")
+    if not raw or raw.count("\t") < 3:
+        continue
+    name, wave, pair, payload = raw.split("\t", 3)
+    if name not in repos:
+        repos[name] = {"rows": [], "status": "ok", "wave": wave, "pair": pair}
+        order.append(name)
+    if payload in ("MISSING", "ERROR"):
+        repos[name]["status"] = "no ledger" if payload == "MISSING" else "unreadable"
+        continue
+    try:
+        repos[name]["rows"].append(json.loads(payload))
+    except ValueError:
+        repos[name]["status"] = "malformed rows"
+
+
+def is_baseline(row):
+    """A measurement, not a curation. Baseline rows establish the starting
+    number and must not be scored as though the skill had done work."""
+    acts = row.get("actions") or []
+    return bool(acts) and all(a.split(":", 1)[0] == "baseline" for a in acts)
+
+
+def score_repo(name, info):
+    rec = {
+        "repo": name, "wave": info["wave"], "pair": info["pair"],
+        "status": None, "why": None, "before": None, "after": None,
+        "budget": None, "closure": None, "no_loss": None,
+        "skill_version": None, "ts": None, "gates": [],
+    }
+    if info["status"] != "ok":
+        rec["status"] = "unscorable"
+        rec["why"] = info["status"]
+        return rec
+    # ts is a date, so several runs on one day tie. sorted() is stable, so ties
+    # keep ledger order — which is append order, which is the true sequence.
+    rows = sorted(info["rows"], key=lambda r: r.get("ts") or "")
+    if not rows:
+        rec["status"] = "unscorable"
+        rec["why"] = "no ledger rows"
+        return rec
+
+    scored = prev = None
+    for i, r in enumerate(rows):
+        if r.get("skill_version") and not is_baseline(r):
+            scored = r
+            prev = rows[i - 1] if i else None
+            break
+    if scored is None:
+        rec["status"] = "unscorable"
+        rec["why"] = "no attributed curation run yet (only baselines, or no skill_version)"
+        return rec
+
+    rec["skill_version"] = scored.get("skill_version")
+    rec["ts"] = scored.get("ts")
+    rec["after"] = scored.get("tokens")
+    rec["budget"] = scored.get("budget")
+    rec["no_loss"] = scored.get("no_loss")
+
+    # Safety first, and independent of whether the run is scorable for
+    # effectiveness: a run that dropped content is a failure even if its
+    # before-row is missing and no closure can be computed.
+    if scored.get("no_loss") != "ok":
+        got = scored.get("no_loss") or "not recorded"
+        rec["gates"].append(f"no_loss={got}")
+    dead = scored.get("links_dead")
+    if isinstance(dead, int) and dead > 0:
+        rec["gates"].append(f"links_dead={dead}")
+    if prev is not None:
+        a, b = prev.get("docs_orphaned"), scored.get("docs_orphaned")
+        if isinstance(a, int) and isinstance(b, int) and b > a:
+            rec["gates"].append(f"docs_orphaned {a}->{b}")
+
+    if rec["gates"]:
+        rec["status"] = "failed"
+        rec["why"] = "; ".join(rec["gates"])
+        return rec
+
+    if prev is None:
+        rec["status"] = "unscorable"
+        rec["why"] = "no row before the first curation, so there is no before-state"
+        return rec
+    if prev.get("tokens_exact") != scored.get("tokens_exact"):
+        rec["status"] = "unscorable"
+        rec["why"] = "measurement method changed at the scored run"
+        return rec
+    if not isinstance(prev.get("tokens"), int) or not isinstance(rec["after"], int) \
+            or not isinstance(rec["budget"], int):
+        rec["status"] = "unscorable"
+        rec["why"] = "a token count or budget is missing"
+        return rec
+
+    rec["before"] = prev["tokens"]
+    gap_before = max(0, rec["before"] - rec["budget"])
+    gap_after = max(0, rec["after"] - rec["budget"])
+    if gap_before == 0:
+        rec["status"] = "scored"
+        rec["why"] = "already under budget before the run — no gap to close"
+        return rec
+    rec["closure"] = (gap_before - gap_after) / gap_before
+    rec["status"] = "scored"
+    return rec
+
+
+records = [score_repo(n, repos[n]) for n in order]
+by_arm = {treatment: {}, control: {}}
+for r in records:
+    if r["wave"] in by_arm and r["pair"]:
+        by_arm[r["wave"]].setdefault(r["pair"], []).append(r)
+
+pairs = []
+for pid in sorted(set(by_arm[treatment]) | set(by_arm[control]),
+                  key=lambda p: (len(p), p)):
+    t = by_arm[treatment].get(pid, [])
+    c = by_arm[control].get(pid, [])
+    entry = {"pair": pid, "treatment": t[0] if len(t) == 1 else None,
+             "control": c[0] if len(c) == 1 else None,
+             "informative": False, "winner": None, "margin": None, "why": None}
+    if len(t) != 1 or len(c) != 1:
+        entry["why"] = (f"pair {pid} has {len(t)} treatment and {len(c)} control "
+                        "repos; a pair needs exactly one of each")
+        pairs.append(entry)
+        continue
+    tr, cr = t[0], c[0]
+    if tr["status"] != "scored" or cr["status"] != "scored":
+        bad = tr if tr["status"] != "scored" else cr
+        entry["why"] = f"{bad['repo']}: {bad['status']} — {bad['why']}"
+    elif tr["closure"] is None or cr["closure"] is None:
+        side = tr if tr["closure"] is None else cr
+        entry["why"] = f"{side['repo']} had no budget gap to close"
+    elif tr["closure"] >= 1.0 and cr["closure"] >= 1.0:
+        # Closure is capped at 1.0 — a run that cuts far past the budget scores
+        # the same as one that lands on it, deliberately, so over-cutting earns
+        # nothing. The cost is that when both arms reach budget the metric has no
+        # room left to express a difference. Calling that a tie would make the
+        # sweep rule unsatisfiable for any pair that starts close to budget, so
+        # it is uninformative instead: the metric cannot separate them, which is
+        # not the same as their being equal.
+        entry["why"] = ("both arms closed the gap completely — closure saturates "
+                        "and cannot separate them")
+    else:
+        entry["informative"] = True
+        entry["margin"] = tr["closure"] - cr["closure"]
+        if tr["closure"] > cr["closure"]:
+            entry["winner"] = "treatment"
+        elif cr["closure"] > tr["closure"]:
+            entry["winner"] = "control"
+        else:
+            entry["winner"] = "tie"
+    pairs.append(entry)
+
+informative = [p for p in pairs if p["informative"]]
+wins = [p for p in informative if p["winner"] == "treatment"]
+t_failures = [r for r in records if r["wave"] == treatment and r["status"] == "failed"]
+c_failures = [r for r in records if r["wave"] == control and r["status"] == "failed"]
+
+t_versions = sorted({r["skill_version"] for r in records
+                     if r["wave"] == treatment and r["skill_version"]})
+c_versions = sorted({r["skill_version"] for r in records
+                     if r["wave"] == control and r["skill_version"]})
+
+verdict, code, reasons = None, 0, []
+if t_failures:
+    verdict, code = "REJECT", 3
+    reasons.append("a safety gate tripped in the treatment arm: "
+                   + "; ".join(f"{r['repo']} ({r['why']})" for r in t_failures))
+elif not t_versions:
+    verdict, code = "INCONCLUSIVE", 5
+    reasons.append(f"no attributed curation run in the treatment arm (wave "
+                   f"{treatment}) yet — nothing has been measured to compare")
+elif t_versions == c_versions:
+    verdict, code = "INCONCLUSIVE", 5
+    reasons.append(f"both arms ran the same version ({', '.join(t_versions)}); "
+                   "this is a baseline, not a comparison")
+elif len(informative) < min_pairs:
+    verdict, code = "INCONCLUSIVE", 5
+    reasons.append(f"{len(informative)} informative pair(s), minimum {min_pairs}")
+elif len(wins) == len(informative):
+    verdict, code = "ADOPT", 0
+    p = 0.5 ** len(informative)
+    short = 5 - len(informative)
+    caveat = ("" if p <= 0.05 else
+              " — above 0.05, so this sweep is suggestive rather than "
+              f"significant; {short} more informative "
+              f"{'pair' if short == 1 else 'pairs'} would reach the "
+              "conventional threshold")
+    reasons.append(f"the treatment won all {len(informative)} informative pairs "
+                   f"(p={p:.3f}, one-sided sign test){caveat}")
+else:
+    verdict, code = "REJECT", 3
+    lost = [f"pair {p['pair']} -> {p['winner']}" for p in informative
+            if p["winner"] != "treatment"]
+    reasons.append(f"the treatment won {len(wins)} of {len(informative)} "
+                   f"informative pairs; adoption requires all ({'; '.join(lost)})")
+
+if fmt == "json":
+    print(json.dumps({
+        "treatment_wave": treatment, "control_wave": control,
+        "treatment_versions": t_versions, "control_versions": c_versions,
+        "repos": records, "pairs": pairs,
+        "informative_pairs": len(informative), "treatment_wins": len(wins),
+        "min_pairs": min_pairs, "verdict": verdict, "reasons": reasons,
+        "control_arm_failures": [r["repo"] for r in c_failures],
+    }, indent=2))
+    sys.exit(code)
+
+
+def pct(v):
+    return "-" if v is None else f"{v * 100:.1f}%"
+
+
+def num(v):
+    return "-" if not isinstance(v, int) else str(v)
+
+
+w = max([len(r["repo"]) for r in records] + [4])
+print(f"treatment wave {treatment}: {', '.join(t_versions) or 'no attributed runs'}")
+print(f"control   wave {control}: {', '.join(c_versions) or 'no attributed runs'}")
+print()
+print(f"{'pair':>4}  {'arm':<3} {'repo':<{w}} {'before':>8} {'after':>8} "
+      f"{'budget':>7} {'closure':>8}  no_loss")
+print("-" * (w + 48))
+for p in pairs:
+    for tag, r in (("T", p["treatment"]), ("C", p["control"])):
+        if r is None:
+            print(f"{p['pair']:>4}  {tag:<3} (missing)")
+            continue
+        print(f"{p['pair']:>4}  {tag:<3} {r['repo']:<{w}} {num(r['before']):>8} "
+              f"{num(r['after']):>8} {num(r['budget']):>7} {pct(r['closure']):>8}"
+              f"  {r['no_loss'] or '-'}")
+    if p["informative"]:
+        margin = p["margin"] * 100
+        print(f"{'':>4}  -> {p['winner']} ({margin:+.1f}pp)")
+    else:
+        print(f"{'':>4}  -> uninformative: {p['why']}")
+print()
+
+unassigned = [r for r in records if not r["pair"]]
+if unassigned:
+    print("not in any pair: "
+          + ", ".join(f"{r['repo']} (wave {r['wave']})" for r in unassigned))
+if c_failures:
+    print("control-arm safety failures (reported, not a reason to reject the "
+          "proposal):")
+    for r in c_failures:
+        print(f"  {r['repo']}: {r['why']}")
+    print()
+
+print(f"verdict: {verdict}")
+for reason in reasons:
+    print(f"  {reason}")
+if verdict == "REJECT":
+    print("  record this in references/rejected-changes.md with the numbers "
+          "above — a rejection nobody wrote down gets re-proposed.")
+elif verdict == "INCONCLUSIVE":
+    print("  this is not a rejection and does not belong in "
+          "rejected-changes.md. Nothing has been decided; the proposal is "
+          "still pending evidence.")
+sys.exit(code)
+PY
+
+exit "$RC"

--- a/skills/curating-context/scripts/score-cohort.sh
+++ b/skills/curating-context/scripts/score-cohort.sh
@@ -488,6 +488,15 @@ wins = [p for p in informative if p["winner"] == "treatment"]
 
 
 def arm(wave, status):
+    """Every repo in the arm, INCLUDING ones in no pair — deliberately wider
+    than the pairing.
+
+    Safety is not a property of a comparison. Content lost under the proposed
+    version is lost whether or not that repo had a partner, so an unpaired repo
+    can veto adoption on its own while contributing nothing to any closure. It
+    stays visible: it is listed under "not in any pair" and again in the
+    treatment-arm failures block. Do not narrow this to paired repos.
+    """
     return [r for r in records if r["wave"] == wave and r["status"] == status]
 
 
@@ -509,27 +518,41 @@ t_by_version, c_by_version = versions_in(treatment), versions_in(control)
 t_versions, c_versions = sorted(t_by_version), sorted(c_by_version)
 
 
+def version_canon(v):
+    """One version, one spelling: 1.2, 1.2.0 and v1.2 are the same release.
+
+    Two cosmetic differences are normalised away and no others: a leading v, and
+    trailing zero components. Deliberately NOT the numeric key below, which is
+    lossy — it maps every non-numeric component to 0, so 2.0-alpha and 2.0-beta
+    would collapse into one version and two genuinely different prereleases
+    would be reported as no experiment at all.
+
+    The v guard checks that a digit follows, so a release actually named vNext
+    is left alone.
+    """
+    s = str(v).strip()
+    if s[:1] in ("v", "V") and s[1:2].isdigit():
+        s = s[1:]
+    parts = s.split(".")
+    while len(parts) > 1 and parts[-1] in ("0", ""):
+        parts.pop()
+    return ".".join(parts)
+
+
 def version_key(v):
     """Numeric components as a tuple, so 1.10 sorts ABOVE 1.9. Used only to
     decide whether the arms look inverted, never who wins: a non-numeric
     component reads as 0, which is fine for refusing to score and not fine for
-    scoring."""
-    return tuple(int(p) if p.isdigit() else 0 for p in str(v).split("."))
+    scoring.
 
-
-def version_canon(v):
-    """One version, one spelling: 1.2 and 1.2.0 are the same release.
-
-    Deliberately NOT version_key, which is lossy — it maps every non-numeric
-    component to 0, so 2.0-alpha and 2.0-beta would collapse into one version
-    and two genuinely different prereleases would be reported as no experiment
-    at all. This only strips trailing zero components, which is the difference
-    that is always cosmetic.
+    Derived from the canonical form so the two cannot disagree. They did: v1.2
+    keyed to (0, 2) against 1.2's (1, 2), and the gate reported the arms as
+    inverted for one release spelled two ways — a confidently wrong diagnosis
+    pointing at the flags, which were not the problem. Deriving it also settles
+    1.2.0 vs 1.2, which keyed unequal and could trip the same test.
     """
-    parts = str(v).strip().split(".")
-    while len(parts) > 1 and parts[-1] in ("0", ""):
-        parts.pop()
-    return ".".join(parts)
+    return tuple(int(p) if p.isdigit() else 0
+                 for p in version_canon(v).split("."))
 
 
 # Every "is this even an experiment?" test compares CANONICAL versions. Comparing

--- a/skills/curating-context/scripts/score-cohort.sh
+++ b/skills/curating-context/scripts/score-cohort.sh
@@ -26,7 +26,9 @@ Options:
                       the defaults: --treatment b --control a. The defaults suit
                       later rounds, once A has caught up and is the arm carrying
                       a proposal. Get this backwards and a winning change reads
-                      as a losing one.
+                      as a losing one — so an arm carrying only older versions
+                      than the other is detected and returns INCONCLUSIVE rather
+                      than a rejection.
   --ledger PATH       Ledger path within each repo.
                       Default: .skills/context-metrics.jsonl
   --branch NAME       Branch to read for owner/repo entries.
@@ -95,7 +97,15 @@ Exit codes:
   2  infrastructure failure (python3 or gh missing, library missing)
   3  REJECT — a recorded safety gate tripped, or the treatment did not sweep
   5  INCONCLUSIVE — nothing was decided: too few informative pairs, safety
-     unverified, both arms on one version, or an arm split across versions
+     unverified, both arms on one version, an arm split across versions, or the
+     arms look inverted
+
+Every question of the form "is this even an experiment?" is answered BEFORE any
+verdict that would reject, because a REJECT tells the reader to write the change
+into rejected-changes.md — a permanent record. Naming a change as refuted when
+the comparison was mislabelled, or when no proposal existed, is the worst single
+output this script can produce. Treatment-arm safety failures are printed
+whatever the verdict, so the reordering masks nothing.
 USAGE
 }
 
@@ -198,10 +208,16 @@ fi
 
 : >"$TMP/all.jsonl"
 while IFS="$CTX_US" read -r kind entry wave pair; do
-  [ -n "$wave" ] || continue
+  # An entry outside the two arms is REPORTED, not dropped. The roll-up already
+  # refuses to skip a repo silently on the principle that missing telemetry is
+  # itself the finding; a gate that quietly shrinks its own sample is worse,
+  # because a typo'd wave: value removes a repo from the experiment with no
+  # trace anywhere in the output.
   case "$wave" in
     "$TREATMENT"|"$CONTROL") ;;
-    *) continue ;;
+    *) printf '%s\t%s\t%s\t%s\n' "$entry" "$wave" "$pair" "OUT_OF_ARM" \
+         >>"$TMP/all.jsonl"
+       continue ;;
   esac
   # The FULL roster entry is the key, not its basename: OrgA/cli and OrgB/cli
   # would otherwise merge into one record. The reader shortens it for display
@@ -231,11 +247,15 @@ min_pairs = int(min_pairs)
 
 repos = {}
 order = []
+out_of_arm = []
 for raw in open(src, encoding="utf-8"):
     raw = raw.rstrip("\n")
     if not raw or raw.count("\t") < 3:
         continue
     key, wave, pair, payload = raw.split("\t", 3)
+    if payload == "OUT_OF_ARM":
+        out_of_arm.append((key, wave))
+        continue
     if key not in repos:
         repos[key] = {"rows": [], "status": "ok", "wave": wave, "pair": pair}
         order.append(key)
@@ -283,7 +303,8 @@ def score_repo(key, info):
         "repo": display[key], "entry": key, "wave": info["wave"],
         "pair": info["pair"], "status": None, "why": None, "before": None,
         "after": None, "budget": None, "closure": None, "no_loss": None,
-        "skill_version": None, "ts": None, "gates": [], "unverified": [],
+        "skill_version": None, "ts": None, "file": None, "gates": [],
+        "unverified": [],
     }
     if info["status"] != "ok":
         rec["status"] = "unscorable"
@@ -297,8 +318,22 @@ def score_repo(key, info):
         rec["why"] = "no ledger rows"
         return rec
 
-    scored = None
-    for r in rows:
+    # PRIMARY POLICY FILE: the one measured most recently. A ledger may track
+    # several — record-telemetry.sh keys its own deltas by file — so "what did
+    # this repo do" is not answerable until one file is named.
+    #
+    # THIS RULE IS SHARED WITH cohort-report.sh AND MUST STAY IDENTICAL. When the
+    # two disagreed, one ledger produced two irreconcilable pictures of the same
+    # repo: the gate scored sub/AGENTS.md 9,000 -> 8,900 (a 100-token prune, 3.3%
+    # closure) while the roll-up reported AGENTS.md at 7,000, net -43,000. A test
+    # pins the two scripts to the same answer.
+    primary = rows[-1].get("file")
+    other_files = {r.get("file") for r in rows} - {primary}
+    rows = [r for r in rows if r.get("file") == primary]
+    rec["file"] = primary
+
+    scored = scored_idx = None
+    for i, r in enumerate(rows):
         if not r.get("skill_version"):
             continue
         kind = classify_run(r)
@@ -309,22 +344,21 @@ def score_repo(key, info):
             rec["why"] = ("the first attributed run carries no action tags, so it "
                           "cannot be told from a baseline; tag it and re-score")
             return rec
-        scored = r
+        scored, scored_idx = r, i
         break
     if scored is None:
+        extra = (f"; {len(other_files)} other file(s) in this ledger were not "
+                 "scored" if other_files else "")
         rec["status"] = "unscorable"
-        rec["why"] = "no attributed curation run yet (only baselines, or no skill_version)"
+        rec["why"] = (f"no attributed curation run for {primary} yet (only "
+                      f"baselines, or no skill_version){extra}")
         return rec
 
-    # The before-state must come from the SAME policy file. A ledger may track
-    # more than one — record-telemetry.sh computes its own deltas per file — and
-    # taking the row that merely happens to precede this one produced a
-    # fabricated closure: a repo that actually went 50,000 -> 9,000 scored -2900%
-    # off an unrelated file's 6,100.
-    target = scored.get("file")
-    same_file = [r for r in rows if r.get("file") == target]
-    idx = same_file.index(scored)
-    prev = same_file[idx - 1] if idx else None
+    # The before-state is the row before it in the SAME file — carried from the
+    # scan rather than looked up with .index(), which matches by dict equality:
+    # two byte-identical rows (a same-day re-run with no --note) would resolve to
+    # the earlier one and take the before-state a row too early.
+    prev = rows[scored_idx - 1] if scored_idx else None
 
     rec["skill_version"] = scored.get("skill_version")
     rec["ts"] = scored.get("ts")
@@ -478,20 +512,25 @@ inverted = bool(t_versions and c_versions
                 and max(map(version_key, t_versions))
                 < min(map(version_key, c_versions)))
 
+# Order matters, and it is the opposite of the obvious one. Every question of
+# the form "is this even an experiment?" is asked BEFORE any verdict that would
+# reject, because a REJECT tells the reader to write the change into
+# rejected-changes.md — a permanent record that shapes future proposals. Naming
+# a change as refuted when the comparison was mislabelled, or when there was no
+# proposal at all, is the worst single output this script can produce. Treatment
+# safety failures are still printed in the body whatever the verdict, so nothing
+# is masked by the reordering.
 verdict, code, reasons = None, 0, []
-if t_failures:
-    verdict, code = "REJECT", 3
-    reasons.append("a safety gate tripped in the treatment arm: "
-                   + "; ".join(f"{r['repo']} ({r['why']})" for r in t_failures))
-elif t_unverified:
-    # Blocks adoption, like a failure, but is NOT a rejection: nothing was
-    # refuted, the experiment was run without its safety check. Filing that in
-    # rejected-changes.md would record the idea as tested and beaten when it was
-    # neither.
+if inverted:
+    # Detection alone was not enough: the WARN printed at the top and the verdict
+    # then rejected the winning change and told the reader to file it as refuted,
+    # twenty lines below the warning saying not to trust the result.
     verdict, code = "INCONCLUSIVE", 5
-    reasons.append("safety could not be verified in the treatment arm: "
-                   + "; ".join(f"{r['repo']} ({r['why']})" for r in t_unverified)
-                   + " — re-run those curations with --no-loss and re-score")
+    reasons.append(f"the arms look inverted — wave {treatment} carries only "
+                   f"older versions ({', '.join(t_versions)}) than wave "
+                   f"{control} ({', '.join(c_versions)}). Re-run with "
+                   f"--treatment {control} --control {treatment}; as scored "
+                   "here a winning change reads as a losing one")
 elif not t_versions:
     verdict, code = "INCONCLUSIVE", 5
     reasons.append(f"no attributed curation run in the treatment arm (wave "
@@ -512,6 +551,25 @@ elif t_versions == c_versions:
     verdict, code = "INCONCLUSIVE", 5
     reasons.append(f"both arms ran the same version ({', '.join(t_versions)}); "
                    "this is a baseline, not a comparison")
+    if t_failures:
+        # Real, and worth acting on, but it is a finding about the shipped
+        # version rather than grounds to reject a proposal that does not exist.
+        reasons.append("a safety gate did trip under that version — see the "
+                       "treatment-arm failures above; that is a finding about "
+                       "what is shipped, not a rejection of anything proposed")
+elif t_failures:
+    verdict, code = "REJECT", 3
+    reasons.append("a safety gate tripped in the treatment arm: "
+                   + "; ".join(f"{r['repo']} ({r['why']})" for r in t_failures))
+elif t_unverified:
+    # Blocks adoption, like a failure, but is NOT a rejection: nothing was
+    # refuted, the experiment was run without its safety check. Filing that in
+    # rejected-changes.md would record the idea as tested and beaten when it was
+    # neither.
+    verdict, code = "INCONCLUSIVE", 5
+    reasons.append("safety could not be verified in the treatment arm: "
+                   + "; ".join(f"{r['repo']} ({r['why']})" for r in t_unverified)
+                   + " — re-run those curations with --no-loss and re-score")
 elif not informative:
     # Independent of --min-pairs. With --min-pairs 0 the sweep test below reads
     # `0 == 0` and adopts on no evidence whatever — a vacuous pass in the one
@@ -555,9 +613,12 @@ if fmt == "json":
         "repos": records, "pairs": pairs,
         "informative_pairs": len(informative), "treatment_wins": len(wins),
         "min_pairs": min_pairs, "verdict": verdict, "reasons": reasons,
+        "treatment_arm_failures": [r["repo"] for r in t_failures],
+        "treatment_arm_unverified": [r["repo"] for r in t_unverified],
         "control_arm_failures": [r["repo"] for r in c_failures],
         "control_arm_unverified": [r["repo"] for r in c_unverified],
         "arms_may_be_inverted": inverted,
+        "out_of_arm": [{"entry": k, "wave": w or None} for k, w in out_of_arm],
     }, indent=2))
     sys.exit(code)
 
@@ -599,6 +660,24 @@ unassigned = [r for r in records if not r["pair"]]
 if unassigned:
     print("not in any pair: "
           + ", ".join(f"{r['repo']} (wave {r['wave']})" for r in unassigned))
+if out_of_arm:
+    print(f"not in either arm (wave is neither {treatment} nor {control}): "
+          + ", ".join(f"{k} (wave {w or 'unassigned'})" for k, w in out_of_arm))
+if unassigned or out_of_arm:
+    print()
+# Printed whatever the verdict, so that reordering the verdict checks — which
+# put "is this even an experiment?" ahead of any REJECT — cannot mask a real
+# safety failure behind an INCONCLUSIVE.
+if t_failures:
+    print("treatment-arm safety failures:")
+    for r in t_failures:
+        print(f"  {r['repo']}: {r['why']}")
+    print()
+if t_unverified:
+    print("treatment-arm runs with no safety verdict (the check was not run):")
+    for r in t_unverified:
+        print(f"  {r['repo']}: {r['why']}")
+    print()
 if c_failures:
     print("control-arm safety failures (reported, not a reason to reject the "
           "proposal):")

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -38,8 +38,10 @@ GUARD = SCRIPTS / "context-budget-guard.sh"
 DELTA = SCRIPTS / "context-delta.sh"
 MEASURE = SCRIPTS / "measure-context.sh"
 COHORT = SCRIPTS / "cohort-report.sh"
+SCORE = SCRIPTS / "score-cohort.sh"
 INSTALL = SCRIPTS / "install-guard.sh"
 LIB = SCRIPTS / "_context-lib.sh"
+RECORD = SCRIPTS / "record-telemetry.sh"
 
 # ~2.7 bytes/token, so this is comfortably over the 6000 policy budget.
 POLICY_LINE = "- a policy line naming `some/path.py` and explaining why\n"
@@ -1069,3 +1071,346 @@ class TestSkillVersionAttribution:
             capture_output=True, text=True, env=_clean_env(), timeout=30,
         )
         assert "a baseline, not a comparison" in result.stdout, result.stdout
+
+
+# ---------------------------------------------------------------------------
+# The validation gate (#94)
+# ---------------------------------------------------------------------------
+
+
+def _ledger_row(**kw) -> str:
+    row = {
+        "ts": "2026-08-05", "repo": kw.get("repo", "x"), "file": "AGENTS.md",
+        "tokens": None, "tokens_exact": True, "skill_version": None,
+        "skill_commit": None, "budget": 6000, "docs_orphaned": 0,
+        "links_dead": 0, "no_loss": None, "actions": [],
+    }
+    row.update(kw)
+    return json.dumps(row, sort_keys=True)
+
+
+def _arm(root: Path, name: str, before: int, after: int | None, version: str,
+         **kw) -> None:
+    """One cohort member with a baseline row and, optionally, a curation run."""
+    d = root / name / ".skills"
+    d.mkdir(parents=True, exist_ok=True)
+    rows = [_ledger_row(repo=name, tokens=before, actions=["baseline:exact"],
+                        docs_orphaned=kw.get("orph_before", 0))]
+    if after is not None:
+        rows.append(_ledger_row(
+            repo=name, tokens=after, actions=["demote:Big"],
+            skill_version=version, skill_commit="deadbee",
+            no_loss=kw.get("no_loss", "ok"),
+            links_dead=kw.get("links_dead", 0),
+            docs_orphaned=kw.get("orph_after", 0),
+        ))
+    (d / "context-metrics.jsonl").write_text("\n".join(rows) + "\n")
+
+
+def _roster(root: Path, spec: list[tuple[str, str, str]]) -> Path:
+    """spec entries are (name, wave, pair)."""
+    path = root / "cohort"
+    path.write_text("".join(
+        f"{root / name}  wave:{wave} pair:{pair}\n" for name, wave, pair in spec
+    ))
+    return path
+
+
+def _score(roster: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SCORE), "--cohort-file", str(roster),
+         "--treatment", "b", "--control", "a", *args],
+        capture_output=True, text=True, env=_clean_env(), timeout=60,
+    )
+
+
+def _three_good_pairs(root: Path, **treatment_kw) -> Path:
+    """Three matched pairs where the treatment (wave b, v1.2) beats the
+    control (wave a, v1.1) on every one."""
+    # (control before, control after, treatment before, treatment after).
+    # Closures: 69.6/86.0, 72.7/85.0, 76.9/87.5 — the treatment takes all three.
+    pairs = [(52000, 20000, 49000, 12000), (28000, 12000, 26000, 9000),
+             (19000, 9000, 14000, 7000)]
+    spec = []
+    for i, (cb, ca, tb, ta) in enumerate(pairs, start=1):
+        _arm(root, f"ctl{i}", cb, ca, "1.1")
+        _arm(root, f"trt{i}", tb, ta, "1.2", **treatment_kw)
+        spec += [(f"ctl{i}", "a", str(i)), (f"trt{i}", "b", str(i))]
+    return _roster(root, spec)
+
+
+class TestValidationGate:
+    """score-cohort.sh is the mechanism #94 asked for: the cohort as a held-out
+    validation split, with a binary adopt/reject gate rather than judgement."""
+
+    def test_sweep_adopts(self, tmp_path: Path):
+        r = _score(_three_good_pairs(tmp_path))
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "verdict: ADOPT" in r.stdout
+        assert "won all 3 informative pairs" in r.stdout
+
+    def test_one_lost_pair_rejects(self, tmp_path: Path):
+        """Adoption requires a win on EVERY informative pair. A majority rule at
+        this sample size is a rule for adopting noise."""
+        roster = _three_good_pairs(tmp_path)
+        # Make the treatment lose pair 3 outright.
+        _arm(tmp_path, "trt3", 14000, 13000, "1.2")
+        r = _score(roster)
+        assert r.returncode == 3, r.stdout + r.stderr
+        assert "verdict: REJECT" in r.stdout
+        assert "won 2 of 3" in r.stdout
+        assert "pair 3 -> control" in r.stdout
+
+    def test_a_tie_is_not_a_win(self, tmp_path: Path):
+        """'No measurable difference' is a rejection, not a pass."""
+        roster = _three_good_pairs(tmp_path)
+        _arm(tmp_path, "ctl3", 19000, 7000, "1.1")
+        _arm(tmp_path, "trt3", 19000, 7000, "1.2")
+        r = _score(roster)
+        assert r.returncode == 3, r.stdout
+        assert "pair 3 -> tie" in r.stdout
+
+    @pytest.mark.parametrize("kw,marker", [
+        ({"no_loss": "failed"}, "no_loss=failed"),
+        ({"no_loss": None}, "no_loss=not recorded"),
+        ({"links_dead": 2}, "links_dead=2"),
+        ({"orph_before": 0, "orph_after": 4}, "docs_orphaned 0->4"),
+    ])
+    def test_safety_gate_vetoes_a_winning_score(self, tmp_path: Path, kw, marker):
+        """A change that reduces tokens by dropping content, breaking links, or
+        orphaning docs is rejected however good its numbers are. There is no
+        exchange rate at which that trade is acceptable, so the gate is a veto
+        rather than a term in a weighted sum."""
+        r = _score(_three_good_pairs(tmp_path, **kw))
+        assert r.returncode == 3, r.stdout + r.stderr
+        assert "verdict: REJECT" in r.stdout
+        assert "safety gate tripped in the treatment arm" in r.stdout
+        assert marker in r.stdout
+
+    def test_missing_no_loss_is_not_a_pass(self, tmp_path: Path):
+        """The pin for the asymmetry: a run that skipped Phase 6 must not clear
+        a Phase 6 gate by silence. Deliberately separate from the parametrised
+        case above, because this is the one an implementation is most likely to
+        get wrong by treating absent as fine."""
+        r = _score(_three_good_pairs(tmp_path, no_loss=None))
+        assert r.returncode == 3
+        assert "not recorded" in r.stdout
+
+    def test_control_arm_failure_is_reported_not_fatal(self, tmp_path: Path):
+        """A gate tripping under the CURRENT version is a finding about today,
+        not a reason to refuse tomorrow's proposal."""
+        roster = _three_good_pairs(tmp_path)
+        _arm(tmp_path, "ctl2", 28000, 12000, "1.1", no_loss="failed")
+        # Pair 2 drops out as uninformative, so --min-pairs 2 keeps the run
+        # decidable and the assertion stays on the claim being made: a failure
+        # under the current version does not block adoption of the next one.
+        r = _score(roster, "--min-pairs", "2")
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "verdict: ADOPT" in r.stdout
+        assert "control-arm safety failures" in r.stdout
+        assert "ctl2" in r.stdout
+        assert "not a reason to reject the proposal" in r.stdout
+
+    def test_saturated_pair_is_uninformative_not_a_tie(self, tmp_path: Path):
+        """Closure caps at 1.0, so when both arms reach budget the metric cannot
+        express a difference. Scoring that as a tie would make the sweep rule
+        unsatisfiable for any pair starting close to budget."""
+        _arm(tmp_path, "ctl1", 6200, 5000, "1.1")
+        _arm(tmp_path, "trt1", 6100, 4000, "1.2")
+        roster = _roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")])
+        r = _score(roster, "--min-pairs", "1")
+        assert "saturates" in r.stdout, r.stdout
+        assert "-> tie" not in r.stdout
+        assert r.returncode == 5
+
+    def test_no_gap_pair_is_uninformative(self, tmp_path: Path):
+        """A repo already under budget has no gap to close; it is not a 0 or a 1."""
+        _arm(tmp_path, "ctl1", 5400, 5200, "1.1")
+        _arm(tmp_path, "trt1", 5300, 5100, "1.2")
+        roster = _roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")])
+        r = _score(roster, "--min-pairs", "1")
+        assert "no budget gap to close" in r.stdout, r.stdout
+        assert r.returncode == 5
+
+    def test_same_version_in_both_arms_is_inconclusive(self, tmp_path: Path):
+        """A uniform cohort is a baseline, not a comparison — and must not read
+        as a rejection of the thing it never tested."""
+        pairs = [(52000, 12000, 49000, 20000), (28000, 8000, 26000, 12000),
+                 (19000, 7000, 14000, 9000)]
+        spec = []
+        for i, (cb, ca, tb, ta) in enumerate(pairs, start=1):
+            _arm(tmp_path, f"ctl{i}", cb, ca, "1.1")
+            _arm(tmp_path, f"trt{i}", tb, ta, "1.1")
+            spec += [(f"ctl{i}", "a", str(i)), (f"trt{i}", "b", str(i))]
+        r = _score(_roster(tmp_path, spec))
+        assert r.returncode == 5, r.stdout
+        assert "both arms ran the same version" in r.stdout
+
+    def test_inconclusive_is_not_filed_as_a_rejection(self, tmp_path: Path):
+        """Recording a non-result in rejected-changes.md would teach a later
+        reader that the idea was tested and failed."""
+        _arm(tmp_path, "ctl1", 52000, 12000, "1.1")
+        _arm(tmp_path, "trt1", 49000, 20000, "1.2")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]))
+        assert r.returncode == 5
+        assert "does not belong in" in r.stdout
+        assert "record this in references/rejected-changes.md" not in r.stdout
+
+    def test_reject_points_at_the_rejection_buffer(self, tmp_path: Path):
+        roster = _three_good_pairs(tmp_path)
+        _arm(tmp_path, "trt3", 14000, 13000, "1.2")
+        r = _score(roster)
+        assert "references/rejected-changes.md" in r.stdout
+
+    def test_baseline_only_repo_is_unscorable_not_scored(self, tmp_path: Path):
+        """A baseline row is a measurement, not a curation."""
+        _arm(tmp_path, "ctl1", 52000, None, "1.1")
+        _arm(tmp_path, "trt1", 49000, 20000, "1.2")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1")
+        assert r.returncode == 5, r.stdout
+        assert "no attributed curation run" in r.stdout
+
+    def test_unannotated_roster_refuses_rather_than_reporting_nothing(
+            self, tmp_path: Path):
+        """An empty comparison must not read as an experiment that found nothing."""
+        path = tmp_path / "cohort"
+        path.write_text("CannObserv/archiver\nCannObserv/notifier\n")
+        r = subprocess.run(
+            ["bash", str(SCORE), "--cohort-file", str(path)],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        assert r.returncode == 1
+        assert "no wave assignment" in r.stderr
+        assert "wave:a pair:1" in r.stderr
+
+    def test_same_wave_for_both_arms_is_a_usage_error(self, tmp_path: Path):
+        r = subprocess.run(
+            ["bash", str(SCORE), "--treatment", "a", "--control", "a"],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        assert r.returncode == 1
+        assert "same wave" in r.stderr
+
+    def test_json_format_carries_the_verdict_and_the_pairs(self, tmp_path: Path):
+        r = _score(_three_good_pairs(tmp_path), "--format", "json")
+        payload = json.loads(r.stdout)
+        assert payload["verdict"] == "ADOPT"
+        assert payload["treatment_versions"] == ["1.2"]
+        assert payload["control_versions"] == ["1.1"]
+        assert payload["informative_pairs"] == 3
+        assert len(payload["pairs"]) == 3
+
+    def test_sweep_below_significance_says_so(self, tmp_path: Path):
+        """Three pairs is p=0.125. The gate must not let a sweep read as proof."""
+        r = _score(_three_good_pairs(tmp_path))
+        assert "p=0.125" in r.stdout
+        assert "suggestive rather than significant" in r.stdout
+
+
+class TestRosterAnnotations:
+    """The roster is parsed by one function in the library, because two parsers
+    would be two opinions about the experiment's own assignment."""
+
+    def test_empty_wave_does_not_shift_the_pair_field(self, tmp_path: Path):
+        """The reason the roster is not tab-separated: `IFS=$'\\t' read` collapses
+        runs of tabs, so an unassigned wave would silently slide the pair value
+        into the wave variable and put a repo in the wrong arm."""
+        path = tmp_path / "cohort"
+        path.write_text("owner/one  pair:7\nowner/two  wave:b pair:7\n")
+        out = subprocess.run(
+            ["bash", "-c",
+             f'. "{LIB}"; ctx_read_roster "{path}" | tr "\\037" "|"'],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        assert out.stdout.splitlines() == ["repo|owner/one||7", "repo|owner/two|b|7"]
+
+    def test_unknown_annotation_warns_and_is_ignored(self, tmp_path: Path):
+        path = tmp_path / "cohort"
+        path.write_text("owner/one  wave:a cohort:x\n")
+        out = subprocess.run(
+            ["bash", "-c", f'. "{LIB}"; ctx_read_roster "{path}" | tr "\\037" "|"'],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        assert "unknown roster annotation" in out.stderr
+        assert out.stdout.strip() == "repo|owner/one|a|"
+
+    def test_comments_and_local_paths_still_parse(self, tmp_path: Path):
+        path = tmp_path / "cohort"
+        path.write_text("# a comment\n\n/abs/path  wave:a pair:1\nowner/two\n")
+        out = subprocess.run(
+            ["bash", "-c", f'. "{LIB}"; ctx_read_roster "{path}" | tr "\\037" "|"'],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        assert out.stdout.splitlines() == ["local|/abs/path|a|1", "repo|owner/two||"]
+
+    def test_shipped_roster_is_fully_paired(self):
+        """Every cohort member is in exactly one pair, each pair holds one repo
+        from each arm, and the arms are the same size. A half-assigned roster
+        would produce a verdict from whichever repos happened to be annotated."""
+        root = Path(__file__).resolve().parent.parent.parent
+        out = subprocess.run(
+            ["bash", "-c",
+             f'. "{LIB}"; ctx_read_roster "{root / ".skills" / "cohort"}"'],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        rows = [line.split("\x1f") for line in out.stdout.splitlines()]
+        assert len(rows) == 12
+        assert all(wave in ("a", "b") and pair for _, _, wave, pair in rows)
+        by_pair: dict[str, list[str]] = {}
+        for _, _, wave, pair in rows:
+            by_pair.setdefault(pair, []).append(wave)
+        assert len(by_pair) == 6
+        assert all(sorted(v) == ["a", "b"] for v in by_pair.values())
+
+    def test_rollup_reports_the_split(self, tmp_path: Path):
+        """The split is a property of the cohort, so it belongs in the roll-up
+        and not only inside the gate."""
+        _arm(tmp_path, "one", 9000, 5000, "1.1")
+        _arm(tmp_path, "two", 9000, None, "1.1")
+        roster = _roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")])
+        r = subprocess.run(
+            ["bash", str(COHORT), "--cohort-file", str(roster)],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "validation split" in r.stdout
+        assert "wave a: 1 repos, 1 adopted" in r.stdout
+        assert "wave b: 1 repos, 0 adopted" in r.stdout
+
+
+class TestNoLossOnTheRow:
+    """--no-loss is what puts Phase 6's verdict where the gate can read it."""
+
+    def test_verdict_lands_on_the_row(self, tmp_path: Path):
+        repo = _repo(tmp_path, policy_lines=10)
+        out = subprocess.run(
+            ["bash", "-c",
+             f'cd "{repo}" && bash "{MEASURE}" --no-write 2>/dev/null'
+             f' | bash "{RECORD}" --dry-run --no-loss ok'],
+            capture_output=True, text=True, env=_clean_env(), timeout=60,
+        )
+        assert json.loads(out.stdout)["no_loss"] == "ok"
+
+    def test_absent_flag_records_null_not_ok(self, tmp_path: Path):
+        repo = _repo(tmp_path, policy_lines=10)
+        out = subprocess.run(
+            ["bash", "-c",
+             f'cd "{repo}" && bash "{MEASURE}" --no-write 2>/dev/null'
+             f' | bash "{RECORD}" --dry-run'],
+            capture_output=True, text=True, env=_clean_env(), timeout=60,
+        )
+        assert json.loads(out.stdout)["no_loss"] is None
+
+    def test_unrecognised_verdict_is_refused(self, tmp_path: Path):
+        """A gate reads anything but 'ok' as not-ok, so a typo would be a silent
+        permanent failure — and a leniently-normalised 'OK' a silent pass."""
+        repo = _repo(tmp_path, policy_lines=10)
+        out = subprocess.run(
+            ["bash", "-c",
+             f'cd "{repo}" && bash "{MEASURE}" --no-write 2>/dev/null'
+             f' | bash "{RECORD}" --dry-run --no-loss OK'],
+            capture_output=True, text=True, env=_clean_env(), timeout=60,
+        )
+        assert out.returncode == 1
+        assert "must be ok, failed, or skipped" in out.stderr

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -1526,11 +1526,16 @@ class TestValidationGateRoundSix:
         assert {x["repo"] for x in json.loads(r.stdout)["repos"]} == {
             "ctl1", "ctl2", "ctl3", "trt1", "trt2", "trt3"}
 
-    def test_inverted_arms_are_detected(self, tmp_path: Path):
+    def test_inverted_arms_are_detected_and_refuse_to_reject(self, tmp_path: Path):
         """Wave A adopts first and holds the OLDER version, so running the
-        script bare during round one inverts the comparison and reports REJECT
-        for a winning change. Documented in three places, which is itself the
-        signal it needed detecting."""
+        script bare during round one inverts the comparison.
+
+        Detection alone was not enough: the WARN printed at the top and the
+        verdict then rejected the winning change and told the reader to file it
+        in rejected-changes.md, twenty lines below the warning saying not to
+        trust the result. A rejection entry is permanent and shapes future
+        proposals, so recording a *winning* change as refuted is the worst
+        single output this script can produce."""
         roster = _three_good_pairs(tmp_path)
         r = subprocess.run(
             ["bash", str(SCORE), "--cohort-file", str(roster),
@@ -1539,6 +1544,10 @@ class TestValidationGateRoundSix:
         )
         assert "arms look" in r.stdout, r.stdout
         assert "--treatment b --control a" in r.stdout
+        assert r.returncode == 5
+        assert "verdict: INCONCLUSIVE" in r.stdout
+        assert "verdict: REJECT" not in r.stdout
+        assert "record this in references/rejected-changes.md" not in r.stdout
 
     def test_correctly_ordered_arms_are_not_warned_about(self, tmp_path: Path):
         r = _score(_three_good_pairs(tmp_path))
@@ -1601,3 +1610,145 @@ class TestCohortReportSingleFile:
         # would read +8500.
         assert cells["net"] == "0", cells
         assert cells["runs"] == "2", cells
+
+
+def _two_file_ledger(root: Path, name: str, version: str,
+                     main_after: int, sub_after: int) -> None:
+    """A repo whose ledger tracks two policy files: a big curation on the
+    primary one, and a trivial prune on a secondary one recorded earlier."""
+    d = root / name / ".skills"
+    d.mkdir(parents=True)
+    (d / "context-metrics.jsonl").write_text("\n".join([
+        _ledger_row(repo=name, ts="2026-08-01", tokens=50000,
+                    actions=["baseline:exact"]),
+        _ledger_row(repo=name, ts="2026-08-01", file="sub/AGENTS.md",
+                    tokens=9000, actions=["baseline:exact"]),
+        _ledger_row(repo=name, ts="2026-08-02", file="sub/AGENTS.md",
+                    tokens=sub_after, actions=["prune:tiny"],
+                    skill_version=version, no_loss="ok"),
+        _ledger_row(repo=name, ts="2026-08-03", tokens=main_after,
+                    actions=["demote:Big"], skill_version=version,
+                    no_loss="ok"),
+    ]) + "\n")
+
+
+class TestValidationGateRoundSeven:
+    def test_gate_scores_the_primary_policy_file(self, tmp_path: Path):
+        """The scan took the first curation across ALL files, so a trivial prune
+        recorded a day earlier on a secondary file was scored instead of the
+        real one: sub/AGENTS.md 9,000 -> 8,900 (3.3%) rather than AGENTS.md
+        50,000 -> 7,000 (93.2%)."""
+        _two_file_ledger(tmp_path, "ctl1", "1.1", main_after=7000, sub_after=8900)
+        _two_file_ledger(tmp_path, "trt1", "1.2", main_after=9000, sub_after=8800)
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1", "--format", "json")
+        by = {x["repo"]: x for x in json.loads(r.stdout)["repos"]}
+        assert by["ctl1"]["file"] == "AGENTS.md", by["ctl1"]
+        assert by["ctl1"]["before"] == 50000
+        assert by["ctl1"]["after"] == 7000
+        assert by["trt1"]["after"] == 9000
+        # The control did the better job on the primary file, so no adoption.
+        assert json.loads(r.stdout)["verdict"] == "REJECT"
+
+    def test_gate_and_rollup_agree_on_which_file_a_repo_is(self, tmp_path: Path):
+        """One ledger produced two irreconcilable pictures of the same repo.
+        The rule is duplicated in two languages, so pin them to one answer."""
+        _two_file_ledger(tmp_path, "one", "1.1", main_after=7000, sub_after=8900)
+        gate = _score(_roster(tmp_path, [("one", "a", "1")]),
+                      "--min-pairs", "1", "--format", "json")
+        rollup = subprocess.run(
+            ["bash", str(COHORT), "--local", str(tmp_path / "one"),
+             "--format", "tsv"],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        cells = dict(zip(*(line.split("\t")
+                           for line in rollup.stdout.splitlines()[:2])))
+        gate_rec = json.loads(gate.stdout)["repos"][0]
+        assert gate_rec["file"] == "AGENTS.md"
+        assert int(cells["tokens"]) == gate_rec["after"] == 7000
+        assert int(cells["runs"]) == 2      # AGENTS.md rows only
+
+    def test_uncurated_primary_file_names_the_file_and_the_others(
+            self, tmp_path: Path):
+        """Scoring a secondary file instead would be the bug this replaced; the
+        honest answer names what was skipped rather than dropping the repo."""
+        d = tmp_path / "one" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo="one", ts="2026-08-01", file="sub/AGENTS.md",
+                        tokens=9000, actions=["baseline:exact"]),
+            _ledger_row(repo="one", ts="2026-08-02", file="sub/AGENTS.md",
+                        tokens=7000, actions=["demote:X"], skill_version="1.1",
+                        no_loss="ok"),
+            _ledger_row(repo="one", ts="2026-08-03", tokens=50000,
+                        actions=["baseline:exact"]),
+        ]) + "\n")
+        _arm(tmp_path, "two", 49000, 12000, "1.2")
+        r = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
+                   "--min-pairs", "1")
+        assert "no attributed curation run for AGENTS.md" in r.stdout, r.stdout
+        assert "1 other file(s) in this ledger were not scored" in r.stdout
+
+    def test_same_version_plus_failure_is_not_a_rejection(self, tmp_path: Path):
+        """There is no proposal to reject, so the entry would name no change.
+        The failure is real and must stay visible — it is a finding about the
+        shipped version, the same distinction drawn for the control arm."""
+        _arm(tmp_path, "ctl1", 52000, 20000, "1.1")
+        _arm(tmp_path, "trt1", 49000, 12000, "1.1", no_loss="failed")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1")
+        assert r.returncode == 5, r.stdout
+        assert "both arms ran the same version" in r.stdout
+        assert "not a rejection of anything proposed" in r.stdout
+        assert "record this in references/rejected-changes.md" not in r.stdout
+        # Still visible, not masked by the reordering.
+        assert "treatment-arm safety failures:" in r.stdout
+        assert "no_loss=failed" in r.stdout
+
+    def test_real_failure_still_rejects_when_there_is_a_proposal(
+            self, tmp_path: Path):
+        """The reordering must not have disarmed the veto."""
+        r = _score(_three_good_pairs(tmp_path, no_loss="failed"))
+        assert r.returncode == 3, r.stdout
+        assert "verdict: REJECT" in r.stdout
+        assert "treatment-arm safety failures:" in r.stdout
+
+    def test_out_of_arm_entries_are_reported(self, tmp_path: Path):
+        """A typo'd wave: value removed a repo from the experiment with no trace
+        anywhere in the output — a gate that quietly shrinks its own sample."""
+        roster = _three_good_pairs(tmp_path)
+        _arm(tmp_path, "stray", 9000, 7000, "1.2")
+        with roster.open("a") as fh:
+            fh.write(f"{tmp_path / 'stray'}  wave:x pair:9\n")
+        r = _score(roster)
+        assert "not in either arm" in r.stdout, r.stdout
+        assert "stray" in r.stdout
+        assert "wave x" in r.stdout
+
+    def test_out_of_arm_appears_in_json(self, tmp_path: Path):
+        roster = _three_good_pairs(tmp_path)
+        _arm(tmp_path, "stray", 9000, 7000, "1.2")
+        with roster.open("a") as fh:
+            fh.write(f"{tmp_path / 'stray'}  wave:x pair:9\n")
+        payload = json.loads(_score(roster, "--format", "json").stdout)
+        assert payload["out_of_arm"] == [
+            {"entry": str(tmp_path / "stray"), "wave": "x"}]
+
+    def test_duplicate_rows_do_not_shift_the_before_state(self, tmp_path: Path):
+        """list.index matches by dict equality, not identity, so a byte-identical
+        repeat of the curation row resolved to the earlier one and took the
+        before-state a row too early."""
+        d = tmp_path / "one" / ".skills"
+        d.mkdir(parents=True)
+        dup = _ledger_row(repo="one", ts="2026-08-02", tokens=9000,
+                          actions=["demote:X"], skill_version="1.1",
+                          no_loss="ok")
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo="one", ts="2026-08-01", tokens=50000,
+                        actions=["baseline:exact"]),
+            dup, dup,
+        ]) + "\n")
+        r = _score(_roster(tmp_path, [("one", "a", "1")]), "--min-pairs", "1",
+                   "--format", "json")
+        rec = json.loads(r.stdout)["repos"][0]
+        assert rec["before"] == 50000, rec

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -1898,6 +1898,97 @@ class TestValidationGateRoundEight:
         # The pair lines and the body block each have a reason to name the repos;
         # the verdict does not, and enumerating there is what made the body look
         # deletable.
-        verdict_block = r.stdout.split("verdict:", 1)[1]
+        # "\nverdict: " with the newline and space, not a bare "verdict:" —
+        # that would also match inside a section header ending in the word, and
+        # the assertion would silently check the wrong block and pass.
+        verdict_block = r.stdout.split("\nverdict: ", 1)[1]
         assert "no_loss=failed" not in verdict_block, verdict_block
         assert "treatment-arm safety failures:" in r.stdout
+
+
+class TestValidationGateRoundNine:
+    def test_repeated_roster_entry_is_warned_and_used_once(self, tmp_path: Path):
+        """Merged silently, a repeat halved an experiment without saying so: a
+        roster declaring four entries and two pairs produced one pair, no note,
+        and a verdict of ADOPT."""
+        path = tmp_path / "cohort"
+        path.write_text("owner/one  wave:a pair:1\n"
+                        "owner/two  wave:b pair:1\n"
+                        "owner/one  wave:b pair:2\n")
+        out = subprocess.run(
+            ["bash", "-c", f'. "{LIB}"; ctx_read_roster "{path}" | tr "\\037" "|"'],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        assert "listed more than once" in out.stderr
+        assert "owner/one" in out.stderr
+        assert out.stdout.splitlines() == ["repo|owner/one|a|1", "repo|owner/two|b|1"]
+
+    def test_duplicate_does_not_shrink_the_experiment_silently(
+            self, tmp_path: Path):
+        _arm(tmp_path, "c1", 50000, 20000, "1.1")
+        _arm(tmp_path, "t1", 49000, 12000, "1.2")
+        roster = _roster(tmp_path, [("c1", "a", "1"), ("t1", "b", "1")])
+        with roster.open("a") as fh:
+            fh.write(f"{tmp_path / 'c1'}  wave:b pair:2\n")
+        r = _score(roster, "--min-pairs", "1")
+        assert "listed more than once" in r.stderr, r.stderr
+        payload = json.loads(_score(roster, "--min-pairs", "1",
+                                    "--format", "json").stdout)
+        # One pair, and the repo counted once — not two records and a phantom
+        # pair 2 that never appears in the report.
+        assert len(payload["repos"]) == 2
+        assert len(payload["pairs"]) == 1
+
+    def test_rollup_does_not_double_count_a_repeated_entry(self, tmp_path: Path):
+        """The same duplication inflated `runs` to 4 for a two-row ledger."""
+        _arm(tmp_path, "one", 50000, 20000, "1.1")
+        path = tmp_path / "cohort"
+        path.write_text(f"{tmp_path / 'one'}\n{tmp_path / 'one'}\n")
+        r = subprocess.run(
+            ["bash", str(COHORT), "--cohort-file", str(path), "--format", "tsv"],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        cells = dict(zip(*(line.split("\t")
+                           for line in r.stdout.splitlines()[:2])))
+        assert cells["runs"] == "2", cells
+
+    @pytest.mark.parametrize("a,b", [("1.2", "v1.2"), ("v1.2", "1.2"),
+                                     ("1.2", "1.2.0"), ("V1.2.0", "1.2")])
+    def test_one_release_spelled_two_ways_is_never_an_experiment(
+            self, tmp_path: Path, a, b):
+        """v1.2 keyed to (0, 2) against 1.2's (1, 2), so the gate reported the
+        arms as inverted for one release spelled two ways — a confidently wrong
+        diagnosis pointing at the flags, which were not the problem."""
+        _arm(tmp_path, "one", 50000, 20000, a)
+        _arm(tmp_path, "two", 49000, 12000, b)
+        r = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
+                   "--min-pairs", "1")
+        assert r.returncode == 5, r.stdout
+        assert "both arms ran the same version" in r.stdout
+        assert "arms look inverted" not in r.stdout
+        assert "verdict: ADOPT" not in r.stdout
+
+    def test_a_release_named_vnext_is_left_alone(self, tmp_path: Path):
+        """The v guard requires a digit after it, so a version that merely
+        starts with v is not mangled into a different one."""
+        out = subprocess.run(
+            ["bash", str(SCORE), "--help"],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        assert out.returncode == 0
+        _arm(tmp_path, "one", 50000, 20000, "vNext")
+        _arm(tmp_path, "two", 49000, 12000, "1.2")
+        r = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
+                   "--min-pairs", "1")
+        assert "both arms ran the same version" not in r.stdout, r.stdout
+
+    def test_version_ordering_still_works_after_canonicalisation(
+            self, tmp_path: Path):
+        """Deriving version_key from the canonical form must not break the
+        older/newer test it exists for: 1.10 is still newer than 1.9."""
+        _arm(tmp_path, "one", 50000, 20000, "1.10")
+        _arm(tmp_path, "two", 49000, 12000, "1.9")
+        r = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
+                   "--min-pairs", "1")
+        # Treatment (wave b) is 1.9, control is 1.10 — genuinely inverted.
+        assert "arms look inverted" in r.stdout, r.stdout

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -1672,16 +1672,23 @@ class TestValidationGateRoundSeven:
             self, tmp_path: Path):
         """Scoring a secondary file instead would be the bug this replaced; the
         honest answer names what was skipped rather than dropping the repo."""
+        # AGENTS.md is the primary (3 rows) and was never curated; the curation
+        # happened on a secondary file. Scoring that secondary file instead
+        # would be the bug this replaced.
         d = tmp_path / "one" / ".skills"
         d.mkdir(parents=True)
         (d / "context-metrics.jsonl").write_text("\n".join([
-            _ledger_row(repo="one", ts="2026-08-01", file="sub/AGENTS.md",
-                        tokens=9000, actions=["baseline:exact"]),
-            _ledger_row(repo="one", ts="2026-08-02", file="sub/AGENTS.md",
-                        tokens=7000, actions=["demote:X"], skill_version="1.1",
-                        no_loss="ok"),
+            _ledger_row(repo="one", ts="2026-08-01", tokens=50000,
+                        actions=["baseline:exact"]),
+            _ledger_row(repo="one", ts="2026-08-02", tokens=50000,
+                        actions=["baseline:exact"]),
             _ledger_row(repo="one", ts="2026-08-03", tokens=50000,
                         actions=["baseline:exact"]),
+            _ledger_row(repo="one", ts="2026-08-04", file="sub/AGENTS.md",
+                        tokens=9000, actions=["baseline:exact"]),
+            _ledger_row(repo="one", ts="2026-08-05", file="sub/AGENTS.md",
+                        tokens=7000, actions=["demote:X"], skill_version="1.1",
+                        no_loss="ok"),
         ]) + "\n")
         _arm(tmp_path, "two", 49000, 12000, "1.2")
         r = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
@@ -1752,3 +1759,145 @@ class TestValidationGateRoundSeven:
                    "--format", "json")
         rec = json.loads(r.stdout)["repos"][0]
         assert rec["before"] == 50000, rec
+
+
+class TestValidationGateRoundEight:
+    def test_a_stray_row_cannot_redefine_the_repo(self, tmp_path: Path):
+        """Most-recent-file alone was too fragile: one incidental baseline row
+        for docs/GUIDE.md re-defined a repo that had curated AGENTS.md over
+        three runs, dropping it out of the experiment and collapsing the
+        roll-up's headline to 4,000 tokens / 1 run / no net — a number that then
+        fed the cohort total. Row count is what a stray append cannot flip."""
+        d = tmp_path / "one" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo="one", ts="2026-08-01", tokens=50000,
+                        actions=["baseline:exact"]),
+            _ledger_row(repo="one", ts="2026-08-02", tokens=7000,
+                        actions=["demote:Big"], skill_version="1.1",
+                        no_loss="ok"),
+            _ledger_row(repo="one", ts="2026-08-03", tokens=6800,
+                        actions=["prune:X"], skill_version="1.1", no_loss="ok"),
+            _ledger_row(repo="one", ts="2026-08-04", file="docs/GUIDE.md",
+                        tokens=4000, actions=["baseline:exact"]),
+        ]) + "\n")
+        _arm(tmp_path, "two", 49000, 12000, "1.2")
+        gate = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
+                      "--min-pairs", "1", "--format", "json")
+        rec = next(x for x in json.loads(gate.stdout)["repos"]
+                   if x["repo"] == "one")
+        assert rec["file"] == "AGENTS.md", rec
+        assert rec["status"] == "scored"
+        assert rec["before"] == 50000 and rec["after"] == 7000
+        rollup = subprocess.run(
+            ["bash", str(COHORT), "--local", str(tmp_path / "one"),
+             "--format", "tsv"],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        cells = dict(zip(*(line.split("\t")
+                           for line in rollup.stdout.splitlines()[:2])))
+        assert cells["tokens"] == "6800", cells
+        assert cells["runs"] == "3", cells
+        assert cells["net"] == "-43200", cells
+
+    def test_ties_on_row_count_fall_back_to_most_recent(self, tmp_path: Path):
+        """The tie-break has to stay deterministic, and it has to be the same
+        one cohort-report.sh uses."""
+        _two_file_ledger(tmp_path, "one", "1.1", main_after=7000, sub_after=8900)
+        gate = _score(_roster(tmp_path, [("one", "a", "1")]), "--min-pairs", "1",
+                      "--format", "json")
+        assert json.loads(gate.stdout)["repos"][0]["file"] == "AGENTS.md"
+        rollup = subprocess.run(
+            ["bash", str(COHORT), "--local", str(tmp_path / "one"),
+             "--format", "tsv"],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        cells = dict(zip(*(line.split("\t")
+                           for line in rollup.stdout.splitlines()[:2])))
+        assert cells["tokens"] == "7000", cells
+
+    def test_same_release_spelled_two_ways_is_not_an_experiment(
+            self, tmp_path: Path):
+        """1.2 and 1.2.0 are one release. Comparing the raw strings made them
+        two, and the gate returned ADOPT for a release scored against itself —
+        the mirror of adopting on zero evidence."""
+        _arm(tmp_path, "one", 50000, 20000, "1.2")
+        _arm(tmp_path, "two", 49000, 12000, "1.2.0")
+        r = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
+                   "--min-pairs", "1")
+        assert r.returncode == 5, r.stdout
+        assert "both arms ran the same version" in r.stdout
+        assert "canonicalise to the same release" in r.stdout
+        assert "verdict: ADOPT" not in r.stdout
+
+    def test_prereleases_are_not_collapsed_into_one_version(self, tmp_path: Path):
+        """version_canon must not be version_key: the latter maps every
+        non-numeric component to 0, which would make 2.0-alpha and 2.0-beta the
+        same version and report two real changes as no experiment at all."""
+        _arm(tmp_path, "one", 50000, 20000, "2.0-alpha")
+        _arm(tmp_path, "two", 49000, 12000, "2.0-beta")
+        r = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
+                   "--min-pairs", "1")
+        assert "both arms ran the same version" not in r.stdout, r.stdout
+        assert "verdict: ADOPT" in r.stdout
+
+    def test_empty_control_arm_says_so(self, tmp_path: Path):
+        """The expected intermediate state during the first experiment: wave B
+        adopts before wave A has re-run. 'No informative pairs' is true and
+        sends the reader to look at pair scoring instead of adoption progress."""
+        d = tmp_path / "one" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text(
+            _ledger_row(repo="one", tokens=50000, actions=["baseline:exact"])
+            + "\n")
+        _arm(tmp_path, "two", 49000, 12000, "1.2")
+        r = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
+                   "--min-pairs", "1")
+        assert r.returncode == 5, r.stdout
+        assert "no attributed curation run in the control arm (wave a)" in r.stdout
+        assert "nothing to be compared against" in r.stdout
+
+    def test_split_arm_is_diagnosed_before_inversion(self, tmp_path: Path):
+        """An arm that is not internally coherent cannot meaningfully be called
+        older than the other. Reporting inversion first walked the reader
+        through two diagnoses — swap the flags, hit the split — for one
+        problem."""
+        _arm(tmp_path, "c1", 50000, 20000, "1.3")
+        _arm(tmp_path, "t1", 49000, 12000, "1.1")
+        _arm(tmp_path, "c2", 30000, 14000, "1.3")
+        _arm(tmp_path, "t2", 29000, 9000, "1.2")
+        r = _score(_roster(tmp_path, [("c1", "a", "1"), ("t1", "b", "1"),
+                                      ("c2", "a", "2"), ("t2", "b", "2")]),
+                   "--min-pairs", "1")
+        assert "split across versions" in r.stdout, r.stdout
+        assert "arms look inverted" not in r.stdout
+
+    def test_scored_file_is_named_when_a_ledger_holds_several(
+            self, tmp_path: Path):
+        """Without this the table reads as though the whole history were in
+        view — two repos at 50,000 -> 7,000 with no sign that a prune on a
+        secondary file was excluded from both."""
+        _two_file_ledger(tmp_path, "one", "1.1", main_after=7000, sub_after=8900)
+        _two_file_ledger(tmp_path, "two", "1.2", main_after=9000, sub_after=8800)
+        r = _score(_roster(tmp_path, [("one", "a", "1"), ("two", "b", "1")]),
+                   "--min-pairs", "1")
+        assert "multi-file ledgers" in r.stdout, r.stdout
+        assert "one: AGENTS.md (+1 other file(s) not scored)" in r.stdout
+        assert "two: AGENTS.md (+1 other file(s) not scored)" in r.stdout
+
+    def test_single_file_ledgers_print_no_multi_file_block(self, tmp_path: Path):
+        r = _score(_three_good_pairs(tmp_path))
+        assert "multi-file ledgers" not in r.stdout
+
+    def test_reject_does_not_enumerate_failures_twice(self, tmp_path: Path):
+        """The body block is what keeps failures visible under the INCONCLUSIVE
+        paths, so it must not look redundant enough to delete."""
+        r = _score(_three_good_pairs(tmp_path, no_loss="failed"))
+        assert r.returncode == 3
+        assert "see the treatment-arm failures above" in r.stdout
+        # The pair lines and the body block each have a reason to name the repos;
+        # the verdict does not, and enumerating there is what made the body look
+        # deletable.
+        verdict_block = r.stdout.split("verdict:", 1)[1]
+        assert "no_loss=failed" not in verdict_block, verdict_block
+        assert "treatment-arm safety failures:" in r.stdout

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -1172,7 +1172,6 @@ class TestValidationGate:
 
     @pytest.mark.parametrize("kw,marker", [
         ({"no_loss": "failed"}, "no_loss=failed"),
-        ({"no_loss": None}, "no_loss=not recorded"),
         ({"links_dead": 2}, "links_dead=2"),
         ({"orph_before": 0, "orph_after": 4}, "docs_orphaned 0->4"),
     ])
@@ -1187,20 +1186,32 @@ class TestValidationGate:
         assert "safety gate tripped in the treatment arm" in r.stdout
         assert marker in r.stdout
 
-    def test_missing_no_loss_is_not_a_pass(self, tmp_path: Path):
-        """The pin for the asymmetry: a run that skipped Phase 6 must not clear
-        a Phase 6 gate by silence. Deliberately separate from the parametrised
-        case above, because this is the one an implementation is most likely to
-        get wrong by treating absent as fine."""
-        r = _score(_three_good_pairs(tmp_path, no_loss=None))
-        assert r.returncode == 3
-        assert "not recorded" in r.stdout
+    @pytest.mark.parametrize("verdict,marker", [
+        (None, "no_loss=not recorded"),
+        ("skipped", "no_loss=skipped"),
+    ])
+    def test_missing_no_loss_never_adopts(self, tmp_path: Path, verdict, marker):
+        """A run that skipped Phase 6 must not clear a Phase 6 gate by silence.
+
+        It blocks adoption like a failure, but it is INCONCLUSIVE rather than
+        REJECT: nothing was refuted, the experiment was run without its safety
+        check. Calling it a rejection would file the idea in
+        rejected-changes.md as tested and beaten when it was neither."""
+        r = _score(_three_good_pairs(tmp_path, no_loss=verdict))
+        assert r.returncode == 5, r.stdout
+        assert "verdict: ADOPT" not in r.stdout
+        assert "safety could not be verified in the treatment arm" in r.stdout
+        assert marker in r.stdout
+        assert "re-run those curations with --no-loss" in r.stdout
+        assert "record this in references/rejected-changes.md" not in r.stdout
 
     def test_control_arm_failure_is_reported_not_fatal(self, tmp_path: Path):
         """A gate tripping under the CURRENT version is a finding about today,
         not a reason to refuse tomorrow's proposal."""
         roster = _three_good_pairs(tmp_path)
         _arm(tmp_path, "ctl2", 28000, 12000, "1.1", no_loss="failed")
+        # A genuine recorded failure, not a missing verdict — see
+        # test_control_arm_missing_verdict_is_not_called_a_failure.
         # Pair 2 drops out as uninformative, so --min-pairs 2 keeps the run
         # decidable and the assertion stays on the claim being made: a failure
         # under the current version does not block adoption of the next one.
@@ -1414,3 +1425,179 @@ class TestNoLossOnTheRow:
         )
         assert out.returncode == 1
         assert "must be ok, failed, or skipped" in out.stderr
+
+
+class TestValidationGateRoundSix:
+    """Regressions found reviewing the gate: each of these produced a verdict
+    that was wrong rather than merely unhelpful."""
+
+    def test_before_state_comes_from_the_same_policy_file(self, tmp_path: Path):
+        """A ledger may track more than one policy file. Taking the row that
+        merely happens to precede the curation fabricated the before-state: a
+        repo that really went 50,000 -> 9,000 scored -2900% off an unrelated
+        file's 6,100 and handed the pair to the other arm."""
+        d = tmp_path / "ctl1" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo="ctl1", tokens=50000, actions=["baseline:exact"]),
+            _ledger_row(repo="ctl1", tokens=6100, file="sub/AGENTS.md",
+                        actions=["baseline:exact"]),
+            _ledger_row(repo="ctl1", tokens=9000, actions=["demote:X"],
+                        skill_version="1.1", no_loss="ok"),
+        ]) + "\n")
+        _arm(tmp_path, "trt1", 49000, 9500, "1.2")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1", "--format", "json")
+        ctl = next(x for x in json.loads(r.stdout)["repos"] if x["repo"] == "ctl1")
+        assert ctl["before"] == 50000, ctl
+        # 50,000 -> 9,000 against a 6,000 budget is 93.2% closure, so the
+        # control wins this pair and the treatment must not be adopted.
+        assert round(ctl["closure"], 3) == round((44000 - 3000) / 44000, 3)
+        assert json.loads(r.stdout)["verdict"] == "REJECT"
+
+    def test_min_pairs_zero_is_refused(self, tmp_path: Path):
+        """`--min-pairs 0` let the sweep test read `0 == 0` and adopt on no
+        evidence whatever — a vacuous pass in the control that exists to
+        prevent them."""
+        r = _score(_three_good_pairs(tmp_path), "--min-pairs", "0")
+        assert r.returncode == 1
+        assert "at least 1" in r.stderr
+
+    def test_zero_informative_pairs_never_adopts(self, tmp_path: Path):
+        """Belt to --min-pairs' braces: the sweep branch is guarded on its own,
+        so the two failures cannot line up again."""
+        _arm(tmp_path, "ctl1", 6200, 5000, "1.1")
+        _arm(tmp_path, "trt1", 6100, 4000, "1.2")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1")
+        assert r.returncode == 5, r.stdout
+        assert "no informative pairs" in r.stdout
+        assert "verdict: ADOPT" not in r.stdout
+
+    def test_control_arm_missing_verdict_is_not_called_a_failure(
+            self, tmp_path: Path):
+        """'Failure' in the control-arm report means the shipped version did
+        something wrong. A run nobody checked is not that, and labelling it so
+        is the sort of line that gets quoted in an issue."""
+        roster = _three_good_pairs(tmp_path)
+        _arm(tmp_path, "ctl2", 28000, 12000, "1.1", no_loss=None)
+        r = _score(roster, "--min-pairs", "2")
+        assert "control-arm runs with no safety verdict" in r.stdout, r.stdout
+        assert "not a failure" in r.stdout
+        assert "control-arm safety failures" not in r.stdout
+
+    def test_arm_split_across_versions_is_refused(self, tmp_path: Path):
+        """'Adopt only if strictly better' presumes ONE proposal. A sweep could
+        otherwise be carried by whichever version drew the easier pairs."""
+        for i, (cb, ca, tb, ta) in enumerate(
+                [(50000, 20000, 49000, 12000), (30000, 14000, 29000, 9000)],
+                start=1):
+            _arm(tmp_path, f"ctl{i}", cb, ca, "1.1")
+            _arm(tmp_path, f"trt{i}", tb, ta, "1.2" if i == 1 else "1.9")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1"),
+                                      ("ctl2", "a", "2"), ("trt2", "b", "2")]),
+                   "--min-pairs", "2")
+        assert r.returncode == 5, r.stdout
+        assert "split across versions" in r.stdout
+        assert "no single change to adopt" in r.stdout
+        assert "verdict: ADOPT" not in r.stdout
+
+    def test_basename_collision_keeps_repos_distinct(self, tmp_path: Path):
+        """OrgA/cli and OrgB/cli merged into one record, concatenating two
+        ledgers and reporting an arm as having no attributed run when it had
+        one — a diagnosis that sends someone hunting a ledger that exists."""
+        (tmp_path / "OrgA").mkdir()
+        (tmp_path / "OrgB").mkdir()
+        _arm(tmp_path, "OrgA/cli", 50000, 9000, "1.1")
+        _arm(tmp_path, "OrgB/cli", 49000, 12000, "1.2")
+        roster = _roster(tmp_path, [("OrgA/cli", "a", "1"),
+                                    ("OrgB/cli", "b", "1")])
+        r = _score(roster, "--min-pairs", "1", "--format", "json")
+        payload = json.loads(r.stdout)
+        assert len(payload["repos"]) == 2
+        assert payload["treatment_versions"] == ["1.2"]
+        assert payload["control_versions"] == ["1.1"]
+        # Ambiguous basenames are shown in full rather than identically.
+        assert {x["repo"] for x in payload["repos"]} == {
+            str(tmp_path / "OrgA/cli"), str(tmp_path / "OrgB/cli")}
+
+    def test_unambiguous_basenames_stay_short(self, tmp_path: Path):
+        r = _score(_three_good_pairs(tmp_path), "--format", "json")
+        assert {x["repo"] for x in json.loads(r.stdout)["repos"]} == {
+            "ctl1", "ctl2", "ctl3", "trt1", "trt2", "trt3"}
+
+    def test_inverted_arms_are_detected(self, tmp_path: Path):
+        """Wave A adopts first and holds the OLDER version, so running the
+        script bare during round one inverts the comparison and reports REJECT
+        for a winning change. Documented in three places, which is itself the
+        signal it needed detecting."""
+        roster = _three_good_pairs(tmp_path)
+        r = subprocess.run(
+            ["bash", str(SCORE), "--cohort-file", str(roster),
+             "--treatment", "a", "--control", "b"],
+            capture_output=True, text=True, env=_clean_env(), timeout=60,
+        )
+        assert "arms look" in r.stdout, r.stdout
+        assert "--treatment b --control a" in r.stdout
+
+    def test_correctly_ordered_arms_are_not_warned_about(self, tmp_path: Path):
+        r = _score(_three_good_pairs(tmp_path))
+        assert "arms look" not in r.stdout
+
+    def test_version_comparison_is_numeric_not_lexical(self, tmp_path: Path):
+        """1.10 is newer than 1.9. A string compare says otherwise, which is
+        why the verdict never uses this ordering and the warning does."""
+        _arm(tmp_path, "ctl1", 50000, 20000, "1.9")
+        _arm(tmp_path, "trt1", 49000, 12000, "1.10")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1")
+        assert "arms look" not in r.stdout, r.stdout
+        assert "verdict: ADOPT" in r.stdout
+
+    def test_untagged_attributed_run_is_unscorable(self, tmp_path: Path):
+        """record-telemetry.sh emits actions: [] when --actions was omitted.
+        Scoring that as a curation attributes its near-zero closure to the
+        skill version; skipping past it hides the tagging gap."""
+        d = tmp_path / "trt1" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo="trt1", tokens=49000, actions=["baseline:exact"]),
+            _ledger_row(repo="trt1", tokens=48000, actions=[],
+                        skill_version="1.2", no_loss="ok"),
+        ]) + "\n")
+        _arm(tmp_path, "ctl1", 50000, 20000, "1.1")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1")
+        assert r.returncode == 5, r.stdout
+        assert "no action tags" in r.stdout
+        assert "tag it and re-score" in r.stdout
+
+
+class TestCohortReportSingleFile:
+    def test_net_does_not_span_two_policy_files(self, tmp_path: Path):
+        """Same defect as the gate's before-state, in the roll-up: `net` would
+        span two different files and report a change for one that never moved.
+        That is the class of error the method-change anchoring exists to
+        prevent, so it gets the same treatment."""
+        d = tmp_path / "one" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo="one", tokens=9000, actions=["baseline:exact"]),
+            _ledger_row(repo="one", tokens=500, file="sub/AGENTS.md",
+                        actions=["baseline:exact"]),
+            _ledger_row(repo="one", tokens=9000, actions=["demote:X"],
+                        skill_version="1.1"),
+        ]) + "\n")
+        r = subprocess.run(
+            ["bash", str(COHORT), "--local", str(tmp_path / "one"),
+             "--format", "tsv"],
+            capture_output=True, text=True, env=_clean_env(), timeout=30,
+        )
+        assert r.returncode == 0, r.stderr
+        header, row = r.stdout.splitlines()[0].split("\t"), \
+            r.stdout.splitlines()[1].split("\t")
+        cells = dict(zip(header, row))
+        # AGENTS.md never moved: 9000 both times. Against sub/AGENTS.md's 500 it
+        # would read +8500.
+        assert cells["net"] == "0", cells
+        assert cells["runs"] == "2", cells


### PR DESCRIPTION
Closes #94.

The cohort becomes `curating-context`'s held-out validation split, with a binary adopt/reject gate in place of judgement.

## What the gate scores

Each repo's **first curation** — the first ledger row carrying a `skill_version` whose actions are not purely `baseline*`. A first curation and a fifth are not the same task: the first is where the `docs/` tree gets created, the largest section gets demoted, the index gets written. The pairs exist so first-against-first is a fair comparison.

The effectiveness metric is **budget-gap closure**:

```
gap     = max(0, tokens - budget)
closure = (gap_before - gap_after) / gap_before
```

A fraction rather than a token count, because the cohort spans 5,331 to 52,953 and an absolute reduction would let `usa-wa` decide every verdict on its own.

Two properties came out of testing rather than design:

- **Closure caps at 1.0**, so a run that cuts far past budget scores the same as one that lands on it. Over-cutting earns nothing — `tokens_live` rising while the always-paid cost halved is already in `rejected-changes.md`, and rewarding depth of cut would reintroduce that pressure.
- The cap means that when **both** arms reach budget the metric cannot express a difference. That pair is reported as *uninformative — saturated*, not as a tie. Scoring it as a tie made the sweep rule unsatisfiable for any pair starting near budget, which the fixture caught on the first run.

## Safety is a veto, not a term in a sum

| Gate | Trips when |
|---|---|
| `no_loss` | `prove-no-loss.sh` did not return `ok` |
| `links_dead` | the curated surface has broken links |
| `docs_orphaned` | demotion left more orphans than it found |

Any tripped gate rejects the change whatever the token numbers say. A weighted sum would let a large enough token win pay for a small content loss, and there is no exchange rate at which that trade is acceptable.

Two asymmetries are deliberate and pinned by tests:

- **Missing data is never a pass.** A run with no `no_loss` field is unscorable, not ok — a run that skipped Phase 6 cannot clear a Phase 6 gate by silence. `record-telemetry.sh --no-loss` is the new flag that puts the verdict on the row.
- **A control-arm failure is reported, not fatal.** That is the *current* version failing: a finding about today, not a reason to refuse tomorrow's proposal.

## The adoption rule, and its honest limit

Adopt only on a win in **every** informative pair. Ties and "no measurable difference" are rejections; a majority rule at this sample size is a rule for adopting noise (three-of-four happens 31% of the time by chance).

The cohort supports **four informative pairs at best** — pair 6 starts under budget and pair 5 within 6% of it, so both saturate. A clean sweep of four is **p=0.062**: suggestive, not significant. The gate prints that caveat in its own output rather than letting a sweep read as proof. Twelve repos is the sample that exists; the alternative is not a better experiment but no experiment.

`INCONCLUSIVE` is kept distinct from `REJECT` and explicitly does **not** go in `rejected-changes.md` — filing a non-result there would teach a later reader the idea was tested and failed.

## The split

Pairs are adjacent in the 2026-08-05 exact baseline; wave assignment within each pair balances the secondary axis (Detail Docs index present), two indexed repos per arm.

| Pair | Wave A | | Wave B | | Apart |
|---:|---|---:|---|---:|---:|
| 1 | `usa-wa` | 52,953 | `cannabis.observer-wordpress` | 49,103 | 7% |
| 2 | `observo` | 28,110 | `cannobserv` | 25,949 | 8% |
| 3 | `replicator` | 14,633 | `watcher` | 19,715 | **29%** |
| 4 | `archiver` | 14,358 | `power-map` | 13,298 | 7% |
| 5 | `cli` | 6,013 | `address-validator` | 6,322 | 5% |
| 6 | `notifier` | 5,468 | `wslcb-licensing-tracker` | 5,331 | 3% |

Pair 3 is the weakest match — `watcher` has no size neighbour, and a difference there is partly a difference in difficulty. Recorded in the roster and the reference rather than smoothed over.

**Wave A adopts first and therefore holds the OLDER version, so the first experiment runs `--treatment b --control a`.** The flags are explicit rather than inferred from version strings, because `1.10` sorts below `1.9`.

## Defects found on the way

- **`usage()` collision.** The library defines `usage()`, which silently replaced every caller's on source. Only the convention of parsing args before sourcing kept `--help` working; `cohort-report.sh` printed the library's help the moment it sourced. Renamed `ctx_lib_usage`.
- **`IFS=$'\t' read` collapses runs of tabs.** An unassigned wave would have slid the pair value into the wave variable and put a repo in the wrong arm. The roster is unit-separated; a test pins it.
- **`exit 0` inside an awk rule still runs `END`**, so the `END`'s `exit 1` had the last word and every annotated roster reported as unannotated.

## Verification

- **1,193** structural tests pass (was 1,160); 27 new across `TestValidationGate`, `TestRosterAnnotations`, `TestNoLossOnTheRow`
- `shellcheck -x --severity=warning` clean across all 10 scripts
- `skills-ref validate` — valid
- Six synthetic scenarios exercised end to end: sweep, mixed, content loss, unrecorded verdict, orphan growth, same-version
- Run against the real cohort: `INCONCLUSIVE — no attributed curation run in the treatment arm yet`, which is the correct pre-adoption state

## Cost, stated plainly

`SKILL.md` grew **+256 tokens exact** (7,837 → 8,093), on a file already over the 6,000 budget it enforces. That worsens #95 and is noted there rather than absorbed quietly.

And the gate cannot gate itself: no cohort repo has adopted anything, so v1.2 is the last change that ships unvalidated. `validation-gate.md` says so under *What this gate cannot do* rather than leaving the hole implicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
