### PR TITLE
docs: freeze the pre-registered baseline, record experiment 1's outcome

### DIFF
--- a/skills/curating-context/references/cohort-patterns.md
+++ b/skills/curating-context/references/cohort-patterns.md
@@ -197,6 +197,21 @@ the sibling repo's GitHub URL, or inline the rule.
 
 ## Baseline: policy-file tokens, 2026-08-05
 
+> **Frozen. Do not refresh these numbers in place.**
+>
+> This table is the cohort's **pre-registered before-state**. It was committed at
+> `c10bf7f` on 2026-08-05, before any member repo had curated anything, and the
+> validation split's pairs are defined by it. Because it predates every outcome,
+> it is the one baseline that provably cannot have been chosen to favour an arm —
+> which is the only reason the first experiment's rows can be scored at all
+> ([#116](https://github.com/gregoryfoster/skills/issues/116): the gate needs a
+> before-state and no ledger row carries one).
+>
+> Every repo here has since curated, so as a *description of the cohort today*
+> these numbers are stale by design, and updating them in place would look like an
+> obvious cleanup. It would destroy the experiment. Add a new dated table below
+> instead, and leave this one alone.
+
 Counted with `count_tokens` against `claude-opus-5` — **exact, not estimated**.
 The `est` column is what the old uncalibrated `bytes/4` heuristic reported, kept
 here because the gap is the point.

--- a/skills/curating-context/references/validation-gate.md
+++ b/skills/curating-context/references/validation-gate.md
@@ -237,10 +237,11 @@ non-results and teach a later reader that the idea was tested and failed.
   point: ten review findings, all created by an otherwise clean run, all
   invisible to `tokens`, `links_dead`, `docs_orphaned` and `no_loss`. The
   `seams` field exists so that class is measurable — but wave A's rows predate
-  it, so the first experiment compares wave B's *measured* seam counts against
-  wave A's hand-reviewed ones (observo's 10 is the control datapoint), and only
-  later rounds get a symmetric comparison. A proposal aimed at a defect class
-  the row cannot see yet should add its measurement first, as v1.3 did.
+  it, so the first experiment had no symmetric comparison available: its control
+  datapoint is `observo` re-measured at v1.3 (41 seams on a surface v1.2 had
+  declared finished), not a wave-A row. A proposal aimed at a defect class the row
+  cannot see yet should add its measurement first, as v1.3 did — and note that
+  doing so buys measurability for *later* rounds, not for its own experiment.
 - **It cannot run more than once per proposal.** Each repo has one first
   curation. After both waves have adopted, the split still works for steady-state
   weekly runs, but the effect sizes are far smaller and the metric shifts from
@@ -249,9 +250,50 @@ non-results and teach a later reader that the idea was tested and failed.
   last one that shipped unvalidated, because at the time it shipped no cohort
   repo had adopted anything. That is a genuine hole and not a rhetorical one; the
   honest mitigation is that that change added scripts and a reference rather than
-  altering the keep/cut rubric that decides what gets moved. **v1.3 is the first
-  proposal the gate judges**: wave B adopts it, wave A holds at v1.2, and
-  `score-cohort.sh --treatment b --control a` produces the verdict.
+  altering the keep/cut rubric that decides what gets moved. **v1.3 was the first
+  proposal the gate judged** — see the record below.
+
+## Experiment 1 — v1.3, run 2026-08-10: no verdict
+
+Both arms adopted as designed and the gate produced **no verdict**. Recorded here
+because the design's one-shot property (previous bullet) means this cannot be
+re-run: the cohort's first-curation capital is now spent.
+
+What went right: the arms were clean. All six wave-B repos ran v1.3 (`c1e6273`),
+all six wave-A first curations stand at v1.2 (`3fc7b71`), and every safety gate
+passed in **both** arms — `no_loss=ok`, `links_dead=0`, `docs_orphaned=0` across
+all twelve.
+
+What went wrong, in two layers:
+
+- **The gate scored nothing at all.** Every repo came back `unscorable` for the
+  same reason: the before-state is defined as the previous ledger row, and a first
+  curation is the run that *creates* the ledger. The scored run is precisely the
+  run that can never be scored, and no phase of this skill ever records a
+  baseline row ([#116](https://github.com/gregoryfoster/skills/issues/116)).
+- **The metric could not have judged this proposal anyway.** Scored by hand
+  against the pre-registered 2026-08-05 baseline, ten of twelve repos landed under
+  budget, so `gap_after == 0` and closure pins at exactly 1.0 — four of six pairs
+  uninformative, and the two that discriminate are the only two repos that
+  *missed* budget, one falling to each arm. Closure measures shortfall, not
+  quality, and it is structurally blind to what v1.3 changed
+  ([#117](https://github.com/gregoryfoster/skills/issues/117)).
+
+Per the rule above, this is INCONCLUSIVE and does **not** enter
+`rejected-changes.md`. v1.3 stays shipped and unjudged, which is the accurate
+state.
+
+The evidence that does exist is qualitative and directional: all six v1.3 runs
+recorded `seams: 0`, and `observo` — re-run at v1.3 over the surface its own v1.2
+curation had declared finished — found **41** unacknowledged seams. One control
+datapoint, and the comparison is asymmetric (detection on an unswept surface
+versus resolution during a run), but it is the only measurement of that defect
+class in existence. Wave B's runs also produced #111 and #113 as findings against
+v1.3, so the held-out arm yielded qualitatively even where the gate did not.
+
+The lesson for experiment 2 is that the unit of comparison and the primary metric
+have to be settled — and pre-registered — *before* the treatment arm adopts.
+Choosing either after the rows land is choosing the verdict.
 
 ## Not in scope
 

--- a/skills/curating-context/references/validation-gate.md
+++ b/skills/curating-context/references/validation-gate.md
@@ -78,6 +78,17 @@ adopts *on the proposed version* while wave A keeps running the version before i
 `--treatment b --control a`.** The script's defaults (`--treatment a`) suit later
 rounds, once A is the arm carrying a proposal.
 
+> **Superseded after experiment 1.** This describes how the first experiment was
+> staged, and it worked — the arms came out version-clean. It does not describe
+> how later ones can be. Every cohort repo is on skills-vendor auto-refresh and
+> follow-up issues keep necessitating updates, so **a wave cannot hold a version**:
+> `observo` moved itself to v1.3 within a day of that version existing. Going
+> forward the arms are defined by each row's recorded `skill_version`, not by wave
+> membership, and the `wave:`/`pair:` annotations keep only their staging value —
+> rolling a proposal out to half the cohort first.
+> [#118](https://github.com/gregoryfoster/skills/issues/118) carries the
+> replacement design.
+
 Getting the direction backwards turns a winning change into a losing one, so the
 gate detects it: when the treatment arm's versions are all *older* than the
 control's, it prints a `WARN` naming the inversion and the flags that fix it —


### PR DESCRIPTION
Documentation only. Both waves have adopted, the validation gate has run for the
first time, and it returned no verdict — this records that outcome and defuses two
claims that quietly became false when it did.

Refs #116, #117, #118.

## Why

Three files in `curating-context/references/` described the cohort experiment in
the future tense. A reader arriving fresh — or an agent picking up the 88–118
backlog in batches — would have drawn three wrong conclusions from them, and one of
those wrong conclusions destroys data.

## What changed

**`cohort-patterns.md` — the 2026-08-05 baseline table is frozen.**

That table is now load-bearing: it is the only before-state the first experiment
can be scored against, because no ledger row carries one (#116). It was committed
at `c10bf7f` before any repo adopted, which is what makes it usable — a baseline
that predates every outcome cannot have been chosen to favour an arm.

It is also, read as a description of the cohort today, thoroughly stale: all twelve
repos have since curated. That combination is the hazard. "These numbers are five
days old and wrong, refresh them" is a reasonable-looking cleanup that would delete
the experiment. The table now carries a freeze notice naming the pre-registering
commit and directing any refresh into a new dated table instead.

**`validation-gate.md` — experiment 1's outcome is recorded.**

The file said *"`score-cohort.sh --treatment b --control a` produces the verdict"*,
present tense, as though the result were pending rather than absent. Replaced with
what happened: arms version-clean (all six wave-B repos on `c1e6273`, all six
wave-A first curations on `3fc7b71`), all twelve safety gates passing in both arms,
and no verdict — because the gate cannot score a first curation (#116) and closure
could not have judged this proposal anyway (#117). INCONCLUSIVE, so nothing enters
`rejected-changes.md`.

Recorded rather than left implicit because the design's one-shot property means it
cannot be re-run: the cohort's first-curation capital is spent.

Also corrected a factual claim in the same file — the control datapoint for seams
was described as observo's 10 hand-reviewed findings, which measurement has since
superseded: 41 seams, measured at v1.3 on the surface observo's own v1.2 curation
had declared finished.

**`validation-gate.md` — the staging section is marked superseded.**

It described wave A as holding the older version while wave B adopts a proposal.
That is how experiment 1 ran and it worked, but it cannot describe later rounds:
every cohort repo is on skills-vendor auto-refresh, and `observo` moved itself to
v1.3 within a day of that version existing. Arms are defined by the per-row
`skill_version` stamp from here on; #118 carries the replacement design.

Marked rather than rewritten, deliberately. The section is an accurate record of
how the first experiment was staged, and the same reasoning applies as to the
frozen table: a reader who sees both a claim and its expiry is better served than
one who trusts a claim that has silently become false.

## Verification

`1274 passed, 27 skipped` (`.venv/bin/pytest tests/structural/`), run after the
final edit. No script or schema changes in this PR.
