### PR TITLE
#116 fix: record a baseline row so a first curation has a before-state

### DIFF
--- a/skills/curating-context/SKILL.md
+++ b/skills/curating-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: curating-context
-description: Curates a repo's agent-context surface — AGENTS.md and the reference docs it links — against a token budget, verifying facts before removing them. Measures the policy file and its whole live doc tree, fans out to check falsifiable claims (paths, commands, links, issue refs), classifies each section keep/demote/tighten/delete against an evidence-based rubric, relocates rather than deletes, then records a telemetry row so the cohort can learn which optimisations actually pay. Use when the user says "curate context", "context budget", "hone AGENTS.md", "trim AGENTS.md", or "prune context", and for scheduled weekly maintenance.
+description: Curates a repo's agent-context surface — AGENTS.md and the reference docs it links — against a token budget, verifying facts before removing them. Measures the policy file and its whole live doc tree, fans out to check falsifiable claims (paths, commands, links, issue refs), classifies each section keep/demote/tighten/delete against an evidence-based rubric, relocates rather than deletes, then records a before-and-after telemetry pair so the cohort can learn which optimisations actually pay. Use when the user says "curate context", "context budget", "hone AGENTS.md", "trim AGENTS.md", or "prune context", and for scheduled weekly maintenance.
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git, bash, and python3. Optionally uses gh for issue verification and the cohort roll-up, and ANTHROPIC_API_KEY for exact token counts.
 metadata:
   author: gregoryfoster
@@ -148,6 +148,13 @@ in [experiment 1](references/validation-gate.md), which scored nothing
 The row costs one command and lands in the same commit as the curation. Phase 7
 appends the after-row; **never rewrite the baseline row to match it** — the pair
 is the measurement.
+
+**Be on a branch before you run this.** This is the first write of the run, and
+it writes a tracked file. Phases 6 and 6.5 already presume a branch point exists
+(`--base <branch-point>`) and Phase 7 commits there; the skill never says to
+create it, so create it here. An aborted run otherwise leaves a modified ledger
+on whatever branch you started from, which for an autonomous run is the one
+place this skill forbids writing to.
 
 ### A credential is not optional, even interactively
 

--- a/skills/curating-context/SKILL.md
+++ b/skills/curating-context/SKILL.md
@@ -4,7 +4,7 @@ description: Curates a repo's agent-context surface — AGENTS.md and the refere
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git, bash, and python3. Optionally uses gh for issue verification and the cohort roll-up, and ANTHROPIC_API_KEY for exact token counts.
 metadata:
   author: gregoryfoster
-  version: "1.3"
+  version: "1.4"
   triggers: curate context, context budget, hone AGENTS.md, trim AGENTS.md, prune context
 ---
 
@@ -122,13 +122,32 @@ refuses at the very end.
 ## Phase 1 — Measure
 
 ```bash
-bash "<SKILL_SCRIPTS>/measure-context.sh" --exact > /tmp/context-baseline.json
+bash "<SKILL_SCRIPTS>/measure-context.sh" --exact \
+  | tee /tmp/context-baseline.json \
+  | bash "<SKILL_SCRIPTS>/record-telemetry.sh" --baseline
 ```
 
 `--exact` counts via the Anthropic `count_tokens` endpoint — the only accurate
 tokenizer for Claude models, and **free to call**. Run it always; without a
 credential it degrades to a calibrated offline estimate with a WARN. Never
 substitute `tiktoken` — it is OpenAI's tokenizer and undercounts Claude badly.
+
+### The baseline row is not optional either
+
+`--baseline` appends a measurement-only row for the surface **as found**, before
+any edit. It is what makes this run scorable at all.
+
+The validation gate takes a run's before-state from the previous ledger row for
+the same file, and a first curation is the run that *creates* the ledger — so
+without this row the scored run is precisely the run that can never be scored,
+and the `docs_orphaned` safety gate has nothing to compare against and cannot
+trip. That is not hypothetical: it is what happened to all twelve cohort repos
+in [experiment 1](references/validation-gate.md), which scored nothing
+([#116](https://github.com/gregoryfoster/skills/issues/116)).
+
+The row costs one command and lands in the same commit as the curation. Phase 7
+appends the after-row; **never rewrite the baseline row to match it** — the pair
+is the measurement.
 
 ### A credential is not optional, even interactively
 

--- a/skills/curating-context/references/budget-and-metrics.md
+++ b/skills/curating-context/references/budget-and-metrics.md
@@ -273,14 +273,18 @@ records a state that has already passed, so a late fix cannot change it.
 
 ### Reading the trend
 
-`record-telemetry.sh --print-trend` prints the last eight runs with per-run
-deltas and net change. Three shapes to recognise:
+`record-telemetry.sh --print-trend` prints the last eight **rows** with per-row
+deltas and net change, and its header separates the two counts — a run writes a
+`baseline` row and a curation row, so eight rows is four runs. Three shapes to
+recognise:
 
 - **Sawtooth** — reductions followed by regrowth. The file is not the problem;
   whatever keeps appending to it is. Look for a skill or hook that writes to
   `AGENTS.md`, and give it a reference doc to write to instead.
 - **Step then flat** — one large demotion, then nothing. Healthy. Subsequent runs
-  should be cheap `baseline` rows.
+  should show a curation row with a delta near zero: the surface is holding.
+  (A `baseline` row is no longer the marker of a quiet week — every run writes
+  one at Phase 1, so it says nothing about what the run found.)
 - **Slow creep with no negative deltas** — nobody is running Phase 5, or every
   run is finding the budget already met and stopping. Check whether the budget is
   set high enough to never bind.

--- a/skills/curating-context/references/budget-and-metrics.md
+++ b/skills/curating-context/references/budget-and-metrics.md
@@ -184,11 +184,16 @@ ad-hoc `curate context` must land in one comparable series.
 
 ## Telemetry
 
-One append-only JSONL row per run at `.skills/context-metrics.jsonl`, committed
+An append-only JSONL ledger at `.skills/context-metrics.jsonl`, committed
 alongside the file it measures. Committed, rather than kept in a central store,
 for three reasons: the row travels with the repo through a transfer, it is
 reviewable in the same PR as the edits it describes, and a run needs no write
 access to any other repo.
+
+A curation run writes **two** rows: a `baseline` row at Phase 1 for the surface
+as found, and the curation row at Phase 7. See
+[the pair, not the row](#the-pair-not-the-row) — a single row records a state,
+and only a pair records a change.
 
 ### Row schema
 
@@ -225,20 +230,46 @@ Use `verb:target`:
 - `split:<doc>` — an over-budget reference doc divided
 - `fix:dead-link`, `fix:stale-command`, `fix:stale-issue-ref` — Phase 2 repairs
 - `relink:<doc>` — an orphan given an index entry
-- `baseline` — a measurement-only run with no edits
+- `baseline` — a measurement-only row, no edits. Written by
+  `record-telemetry.sh --baseline`, which fixes the tag rather than taking
+  `--actions`, so no reader has to guess whether a row describes a state or a
+  change. Every reader — the gate, the roll-up — skips `baseline*` when looking
+  for a curation.
 
 `"cleanup"` and `"misc"` are worse than no tag: they occupy the slot that would
 otherwise have said something.
 
-### One row per run: rewrite within, append across
+### The pair, not the row
+
+A run's measurement is **two rows**: the Phase 1 `baseline` and the Phase 7
+curation. One row alone records a state; the change lives in the difference, and
+every consumer computes it that way — `delta_tokens` against the previous row for
+the same file, and the validation gate's before-state the same.
+
+That is why a first curation was unscorable before this rule existed. It is the
+run that *creates* the ledger, so nothing precedes it, and the gate's scored run
+was exactly the run it could never score: all twelve cohort repos came back
+`unscorable` in experiment 1 ([#116](https://github.com/gregoryfoster/skills/issues/116)).
+The `docs_orphaned` safety gate failed the same way and more quietly — it
+compares against the previous row, so on a first curation it could not trip at
+all.
+
+Both rows ship in the same commit. Do **not** rewrite the baseline row when the
+after-count changes; rewrite the curation row (next section). The baseline is the
+thing being measured against, and a baseline edited to match its outcome measures
+nothing.
+
+### One row per phase: rewrite within, append across
 
 The ledger is append-only **between** runs, and that is where the rule matters:
 a later run that rewrites an old row destroys the trend it was keeping.
 **Within** a run the instinct runs the other way and is correct — when a late
-fix on the same branch shifts the count, rewrite this run's still-unmerged row
-so it describes what actually ships, rather than appending a second row for an
-intermediate state nobody can check out. The test is whether the row's commit
-has merged: unmerged, it is a draft of this run's record; merged, it is history.
+fix on the same branch shifts the count, rewrite this run's still-unmerged
+*curation* row so it describes what actually ships, rather than appending a
+third row for an intermediate state nobody can check out. The test is whether
+the row's commit has merged: unmerged, it is a draft of this run's record;
+merged, it is history. The baseline row is exempt in both directions — it
+records a state that has already passed, so a late fix cannot change it.
 
 ### Reading the trend
 

--- a/skills/curating-context/references/validation-gate.md
+++ b/skills/curating-context/references/validation-gate.md
@@ -59,10 +59,25 @@ Three details decide whether that run is scored at all:
   unscorable and the report names both the file and how many others were skipped;
   when any ledger held more than one file, the report names which was scored,
   because the table has no room for the column.
-- **The before-state comes from that same file.** Taking whichever row happens to
-  precede the curation produced a fabricated closure: a repo that really went
-  50,000 → 9,000 scored **−2900%** against an unrelated file's 6,100, and handed
-  the pair to the other arm.
+- **The before-state comes from that same file** — and it has to *exist*. Taking
+  whichever row happens to precede the curation produced a fabricated closure: a
+  repo that really went 50,000 → 9,000 scored **−2900%** against an unrelated
+  file's 6,100, and handed the pair to the other arm.
+
+  The deeper failure is that for a first curation there was no preceding row at
+  all. It is the run that *creates* the ledger, so the scored run was exactly the
+  run that could never be scored — which is why experiment 1 scored nothing
+  ([#116](https://github.com/gregoryfoster/skills/issues/116)). Phase 1 now
+  records a `baseline` row (`record-telemetry.sh --baseline`) and both rows ship
+  in one commit, so a run carries the state it is compared against. Rows
+  predating that rule stay unscorable; the gate says so as a **gate defect**
+  when every repo in both arms is blocked by one and the same reason, instead of
+  reporting an empty experiment.
+
+  The same absence disarmed a safety gate. `docs_orphaned` trips on a *rise*
+  against the previous row, so with no previous row it could not trip at all —
+  on all twelve first curations. The recorded values were `0`, so nothing was
+  missed in fact, but the check had not run.
 - **An untagged run makes the repo unscorable.** `record-telemetry.sh` emits
   `actions: []` when `--actions` was omitted, and such a row cannot be told from
   a baseline. Scoring it as a curation would attribute its near-zero closure to
@@ -233,6 +248,28 @@ verdict computed over no pairs is not a weaker verdict but no verdict, and the
 sweep test reads `0 == 0` as a win — it adopted on no evidence whatever until
 the branch was guarded on `informative` being non-empty as well.
 
+### A rejection has its own floor
+
+`--min-pairs` governs **adoption**. A failed sweep needs at least **three**
+informative pairs to be recorded as a REJECT, and `--min-pairs` cannot lower
+that; below it the verdict is INCONCLUSIVE, which still blocks adoption and
+still leaves `rejected-changes.md` alone.
+
+The two are not symmetric outputs. An adoption is a decision to ship that gets
+revisited the next time the skill changes. A rejection is written into
+`rejected-changes.md` permanently, by design, and shapes every later proposal —
+which is the whole value of that file and exactly why filling it with artefacts
+is expensive. Experiment 1 came within one flag of it: at `--min-pairs 2` the
+gate would have reached a 1–1 split and written REJECT against v1.3 on the
+strength of two repos, both of them the honest-shortfall cases and one of them
+the pair the roster itself flags as its weakest match at 29% apart
+([#117](https://github.com/gregoryfoster/skills/issues/117)).
+
+The **safety veto is exempt.** A single repo that dropped content rejects on its
+own, with no pairs at all — content lost under the proposed version is lost
+whether or not that repo had a partner, which is also why the arm listing is
+deliberately wider than the pairing.
+
 INCONCLUSIVE is **not** a rejection and does not belong in
 `rejected-changes.md`: nothing has been decided, and the proposal is still
 pending evidence. Recording it as a rejection would poison the buffer with
@@ -305,6 +342,15 @@ v1.3, so the held-out arm yielded qualitatively even where the gate did not.
 The lesson for experiment 2 is that the unit of comparison and the primary metric
 have to be settled — and pre-registered — *before* the treatment arm adopts.
 Choosing either after the rows land is choosing the verdict.
+
+**Fixed since, in v1.4:** Phase 1 records a `baseline` row, so a first curation
+carries the before-state it is scored against and the `docs_orphaned` gate has
+something to compare; a systematic unscorable is reported as a gate defect rather
+than as an empty experiment; and a REJECT now needs three informative pairs
+whatever `--min-pairs` says. None of that recovers experiment 1 — the cohort's
+first-curation capital is spent either way, which is
+[#118](https://github.com/gregoryfoster/skills/issues/118)'s subject. What it
+does is make the *next* run of the gate measure something.
 
 ## Not in scope
 

--- a/skills/curating-context/scripts/cohort-report.sh
+++ b/skills/curating-context/scripts/cohort-report.sh
@@ -35,6 +35,11 @@ Columns:
   single reduction. That last column is the point of the roll-up: it names which
   optimisation actually paid, per repo.
 
+  `runs` counts CURATION rows, not ledger rows. A run writes two — the Phase 1
+  `baseline` for the surface as found and the Phase 7 curation — so a row count
+  reports every repo as having run twice as often as it did. A repo that
+  measured and stopped shows 0 runs and `(baseline only)`.
+
   `net` is anchored at the oldest run that used the SAME measurement method as
   the latest one, not at the first run ever recorded — an exact count and an
   offline estimate differ by ~60% on this content, so a net spanning that change
@@ -204,6 +209,24 @@ display = {
     for short, keys in basenames.items() for key in keys
 }
 
+def is_curation_row(row):
+    """Whether a row records a RUN rather than a state.
+
+    A curation run writes TWO rows — the Phase 1 `baseline` for the surface as
+    found, and the Phase 7 curation — so a row count is twice the run count.
+    Counting rows reported one curation as two runs, in the column a reader
+    consults to answer "is this repo actually running?" (#116).
+
+    THIS RULE IS SHARED WITH score-cohort.sh's classify_run() AND MUST STAY
+    IDENTICAL; a test pins the two to the same answer. An untagged row
+    (actions: []) counts as a run: something happened that nobody tagged, which
+    is a tagging gap rather than a measurement. Only an explicit `baseline*` row
+    is a state.
+    """
+    acts = row.get("actions") or []
+    return not (acts and all(a.split(":", 1)[0] == "baseline" for a in acts))
+
+
 records = []
 for key in order:
     info = repos[key]
@@ -286,7 +309,7 @@ for key in order:
         "net": net,
         "net_from": net_from,
         "net_why": net_why,
-        "runs": len(rows),
+        "runs": sum(1 for r in rows if is_curation_row(r)),
         "orphans": latest.get("docs_orphaned"),
         "dead": latest.get("links_dead"),
         "skill_version": latest.get("skill_version"),
@@ -327,7 +350,11 @@ for r in records:
     best = "-"
     if r["best_delta"] is not None:
         best = f"{r['best_delta']:+d}  {r['best_actions']}"
-    elif r["runs"] == 1:
+    elif r["runs"] == 0:
+        # Zero RUNS, not zero rows: a repo that measured and stopped has a
+        # baseline row and nothing else. Before runs counted curations this read
+        # `== 1`, which meant the same thing when a single row was all a
+        # measurement-only visit produced.
         best = "(baseline only)"
     elif r["status"] != "ok":
         best = r["status"]

--- a/skills/curating-context/scripts/cohort-report.sh
+++ b/skills/curating-context/scripts/cohort-report.sh
@@ -209,6 +209,7 @@ display = {
     for short, keys in basenames.items() for key in keys
 }
 
+
 def is_curation_row(row):
     """Whether a row records a RUN rather than a state.
 
@@ -217,11 +218,14 @@ def is_curation_row(row):
     Counting rows reported one curation as two runs, in the column a reader
     consults to answer "is this repo actually running?" (#116).
 
-    THIS RULE IS SHARED WITH score-cohort.sh's classify_run() AND MUST STAY
-    IDENTICAL; a test pins the two to the same answer. An untagged row
-    (actions: []) counts as a run: something happened that nobody tagged, which
-    is a tagging gap rather than a measurement. Only an explicit `baseline*` row
-    is a state.
+    THIS RULE IS SHARED WITH score-cohort.sh's classify_run() and
+    record-telemetry.sh's is_curation_row(), and MUST STAY IDENTICAL. The
+    neighbouring primary-file rule diverged between exactly these two scripts
+    once and produced two irreconcilable pictures of one repo, so
+    TestCurationRuleIsOneRule feeds a single mixed ledger through all three and
+    pins them to one answer. An untagged row (actions: []) counts as a run:
+    something happened that nobody tagged, which is a tagging gap rather than a
+    measurement. Only an explicit `baseline*` row is a state.
     """
     acts = row.get("actions") or []
     return not (acts and all(a.split(":", 1)[0] == "baseline" for a in acts))

--- a/skills/curating-context/scripts/record-telemetry.sh
+++ b/skills/curating-context/scripts/record-telemetry.sh
@@ -16,6 +16,23 @@ Usage:
 
 Options:
   --ledger PATH    Ledger file. Default: .skills/context-metrics.jsonl
+  --baseline       Record a measurement-only row for the surface AS FOUND,
+                   before any edits. Tagged `baseline`, which every reader
+                   already knows to skip past when looking for a curation.
+
+                   This is what makes a FIRST curation scorable. The validation
+                   gate takes a run's before-state from the previous row for the
+                   same file, and a first curation is the run that creates the
+                   ledger — so without a baseline row the scored run is exactly
+                   the run that can never be scored, and the docs_orphaned gate
+                   has nothing to compare against and silently cannot trip
+                   (#116). Phase 1 records this row; Phase 7 records the
+                   curation, and both ship in the same commit.
+
+                   Refuses --actions (a baseline row is measurement-only, and
+                   its tag is fixed) and --no-loss (nothing was relocated yet).
+                   --note, --seams and --seams-acked are allowed: they measure
+                   the surface as found, which is a before-state too.
   --actions LIST   Comma-separated action tags applied this run, e.g.
                    "demote:Project Layout,prune:Conventions,fix:dead-link".
                    Recorded verbatim so a later run can correlate a token
@@ -85,12 +102,13 @@ Row schema (one JSON object per line):
                     previous row — see delta_unavailable
   delta_days        days since the previous row (null if first)
   delta_unavailable present only when delta_tokens was suppressed; says why
-  actions           action tags from --actions
+  actions           action tags from --actions, or ["baseline"] with --baseline
   note              --note text
 
 Exit codes:
   0  row appended (or printed, with --dry-run)
-  1  usage error, or stdin was not measure-context.sh JSON
+  1  usage error (including --baseline with --actions or --no-loss), or stdin
+     was not measure-context.sh JSON
   2  infrastructure failure (unwritable ledger, python3 missing)
   4  refused: measurement method differs from the previous row for this file
      (pass --allow-method-change to record it anyway)
@@ -107,6 +125,8 @@ REPO_OVERRIDE=""
 DRY=0
 TREND=0
 ALLOW_METHOD_CHANGE=0
+BASELINE=0
+ACTIONS_SET=0
 
 # --actions and --note accept an empty value deliberately, so they cannot use
 # ${2:?...} for arity — and a bare `shift 2` at the end of argv fails under
@@ -118,7 +138,8 @@ need_arg() {
 while [ $# -gt 0 ]; do
   case "$1" in
     --ledger) LEDGER="${2:?--ledger needs a path}"; shift 2 ;;
-    --actions) need_arg "$#" --actions; ACTIONS="$2"; shift 2 ;;
+    --baseline) BASELINE=1; shift ;;
+    --actions) need_arg "$#" --actions; ACTIONS="$2"; ACTIONS_SET=1; shift 2 ;;
     --note) need_arg "$#" --note; NOTE="$2"; shift 2 ;;
     --no-loss) NO_LOSS="${2:?--no-loss needs ok, failed, or skipped}"; shift 2 ;;
     --seams) SEAMS="${2:?--seams needs a count}"; shift 2 ;;
@@ -131,6 +152,27 @@ while [ $# -gt 0 ]; do
     *) echo "ERROR unknown argument: $1" >&2; usage >&2; exit 1 ;;
   esac
 done
+
+# A baseline row records the surface AS FOUND, so the flags that assert
+# something about a curation are refused rather than quietly ignored. --no-loss
+# in particular would put a relocation verdict on a row where nothing was
+# relocated, and the gate reads that field as evidence.
+#
+# --seams/--seams-acked are deliberately NOT refused: a sweep of the surface as
+# found measures the state before the run, which is a before-state like any
+# other and the one #117 argues the next experiment turns on.
+if [ "$BASELINE" -eq 1 ]; then
+  [ "$ACTIONS_SET" -eq 0 ] || {
+    echo "ERROR --baseline and --actions are mutually exclusive: a baseline row" >&2
+    echo "      is measurement-only and carries the fixed tag \`baseline\`." >&2
+    echo "      Record the edits on the Phase 7 row instead." >&2
+    exit 1; }
+  [ -z "$NO_LOSS" ] || {
+    echo "ERROR --baseline and --no-loss are mutually exclusive: nothing has" >&2
+    echo "      been relocated yet, so there is no verdict to record." >&2
+    exit 1; }
+  ACTIONS="baseline"
+fi
 
 # Reject an unrecognised verdict rather than storing it. A gate that reads this
 # field treats anything other than "ok" as not-ok, so a typo would silently be a
@@ -351,7 +393,13 @@ else:
     except OSError as exc:
         print(f"ERROR cannot append to {ledger}: {exc}", file=sys.stderr)
         sys.exit(2)
-    print(f"recorded {row['file']}: {row['tokens']} tokens", file=sys.stderr)
+    # Name the kind of row, not just the number. A baseline row is the one a
+    # reader is most likely to think did not land, because it records a state
+    # rather than a change and its delta is null by construction.
+    kind = " (baseline — the before-state for this run)" \
+        if row["actions"] == ["baseline"] else ""
+    print(f"recorded {row['file']}: {row['tokens']} tokens{kind}",
+          file=sys.stderr)
 
 if trend == "1":
     series = history + [row]

--- a/skills/curating-context/scripts/record-telemetry.sh
+++ b/skills/curating-context/scripts/record-telemetry.sh
@@ -251,6 +251,23 @@ except (ValueError, KeyError) as exc:
     print(f"ERROR stdin is not measure-context.sh JSON: {exc}", file=sys.stderr)
     sys.exit(1)
 
+def is_curation_row(r):
+    """Whether a row records a RUN rather than a state.
+
+    THIS RULE IS SHARED WITH cohort-report.sh's is_curation_row() and
+    score-cohort.sh's classify_run(), and a test pins all three to one answer
+    over a single mixed ledger. An untagged row (actions: []) counts as a run —
+    something happened that nobody tagged, which is a tagging gap rather than a
+    measurement. Only an explicit `baseline*` row is a state.
+    """
+    acts = r.get("actions") or []
+    return not (acts and all(a.split(":", 1)[0] == "baseline" for a in acts))
+
+
+def plural(n, word):
+    return f"{n} {word}" if n == 1 else f"{n} {word}s"
+
+
 # Which skill version produced this row. Absent from measurements taken before
 # the field existed, and null rather than guessed in that case — a wrong
 # attribution is worse than a missing one when the point is to A/B skill changes.
@@ -405,16 +422,11 @@ if trend == "1":
     series = history + [row]
     # Runs, not rows. A curation run writes two rows — the Phase 1 `baseline` and
     # the Phase 7 curation — so len(series) reported one curation as two runs.
-    # THIS RULE IS SHARED WITH cohort-report.sh's is_curation_row() and
-    # score-cohort.sh's classify_run(): an untagged row counts as a run, only an
-    # explicit `baseline*` row is a state. Every row is still PRINTED below; the
-    # baselines are what the deltas are measured against.
-    def _is_curation(r):
-        acts = r.get("actions") or []
-        return not (acts and all(a.split(":", 1)[0] == "baseline" for a in acts))
-
-    n_runs = sum(1 for r in series if _is_curation(r))
-    print(f"\ntrend for {row['file']} ({n_runs} run(s) over {len(series)} rows):",
+    # Every row is still PRINTED below; the baselines are what the deltas are
+    # measured against.
+    n_runs = sum(1 for r in series if is_curation_row(r))
+    print(f"\ntrend for {row['file']} "
+          f"({plural(n_runs, 'run')} over {plural(len(series), 'row')}):",
           file=sys.stderr)
     # Action tags are the point of the ledger, so a real run carries several and a
     # single-line format stops being readable at about three. Wrap onto

--- a/skills/curating-context/scripts/record-telemetry.sh
+++ b/skills/curating-context/scripts/record-telemetry.sh
@@ -403,7 +403,19 @@ else:
 
 if trend == "1":
     series = history + [row]
-    print(f"\ntrend for {row['file']} ({len(series)} runs):", file=sys.stderr)
+    # Runs, not rows. A curation run writes two rows — the Phase 1 `baseline` and
+    # the Phase 7 curation — so len(series) reported one curation as two runs.
+    # THIS RULE IS SHARED WITH cohort-report.sh's is_curation_row() and
+    # score-cohort.sh's classify_run(): an untagged row counts as a run, only an
+    # explicit `baseline*` row is a state. Every row is still PRINTED below; the
+    # baselines are what the deltas are measured against.
+    def _is_curation(r):
+        acts = r.get("actions") or []
+        return not (acts and all(a.split(":", 1)[0] == "baseline" for a in acts))
+
+    n_runs = sum(1 for r in series if _is_curation(r))
+    print(f"\ntrend for {row['file']} ({n_runs} run(s) over {len(series)} rows):",
+          file=sys.stderr)
     # Action tags are the point of the ledger, so a real run carries several and a
     # single-line format stops being readable at about three. Wrap onto
     # continuation lines aligned under the first tag rather than truncating: the

--- a/skills/curating-context/scripts/score-cohort.sh
+++ b/skills/curating-context/scripts/score-cohort.sh
@@ -558,11 +558,17 @@ SYSTEMIC_HINTS = {
 arm_records = records
 # "No repo in either arm can satisfy this rule" is an inference from BREADTH, and
 # at two repos it is not supported — the likelier reading is two non-compliant
-# repos, which is a finding about the cohort and needs a different fix. Require
-# at least two per arm before naming a defect in the gate.
-SYSTEMIC_MIN = 4
+# repos, which is a finding about the cohort and needs a different fix.
+#
+# Counted PER ARM, not over the roster. A roster total let 3 treatment repos and
+# 1 control repo clear a floor of 4 and print the defect, which is the same thin
+# evidence the floor exists to refuse — one arm carrying a single repo says
+# nothing about whether the rule is satisfiable.
+SYSTEMIC_MIN_PER_ARM = 2
+t_arm_n = sum(1 for r in records if r["wave"] == treatment)
+c_arm_n = sum(1 for r in records if r["wave"] == control)
 systemic = systemic_hint = None
-if len(arm_records) >= SYSTEMIC_MIN \
+if min(t_arm_n, c_arm_n) >= SYSTEMIC_MIN_PER_ARM \
         and all(r["status"] == "unscorable" for r in arm_records):
     codes = {r["why_code"] for r in arm_records}
     if len(codes) == 1:

--- a/skills/curating-context/scripts/score-cohort.sh
+++ b/skills/curating-context/scripts/score-cohort.sh
@@ -34,6 +34,15 @@ Options:
   --branch NAME       Branch to read for owner/repo entries.
   --min-pairs N       Fewest informative pairs that can produce a verdict
                       other than INCONCLUSIVE. Minimum 1. Default: 3
+
+                      This governs ADOPTION. A REJECT has its own floor of 3
+                      that --min-pairs cannot lower: an adoption is revisited
+                      the next time the skill changes, while a rejection is
+                      written into rejected-changes.md permanently and shapes
+                      every later proposal. Below the rejection floor a failed
+                      sweep is INCONCLUSIVE. A tripped SAFETY gate is exempt —
+                      one repo that dropped content rejects on its own, with no
+                      pairs at all.
   --format FMT        table (default) or json
   -h, --help          Show this help and exit 0.
 
@@ -47,6 +56,13 @@ What it scores
   The before-state is the previous row FOR THE SAME POLICY FILE. A ledger may
   track several, and an untagged run (actions: []) cannot be told from a
   baseline, so it makes the repo unscorable rather than being guessed at.
+
+  A first curation therefore needs a BASELINE ROW to be scorable at all — it is
+  the run that creates the ledger, so nothing precedes it by construction. Phase
+  1 records that row (`record-telemetry.sh --baseline`) and Phase 7 records the
+  curation; both ship in the same commit. When every repo in both arms is
+  unscorable for one and the same reason, this script says so as a GATE DEFECT
+  rather than reporting an empty experiment (#116).
 
   The effectiveness metric is budget-gap closure:
 
@@ -96,9 +112,11 @@ Exit codes:
   1  usage error, or the roster carries no wave assignment
   2  infrastructure failure (python3 or gh missing, library missing)
   3  REJECT — a recorded safety gate tripped, or the treatment did not sweep
-  5  INCONCLUSIVE — nothing was decided: too few informative pairs, safety
-     unverified, both arms on one version, an arm split across versions, or the
-     arms look inverted
+     over at least the rejection floor of informative pairs
+  5  INCONCLUSIVE — nothing was decided: too few informative pairs, a failed
+     sweep below the rejection floor, safety unverified, every repo in both arms
+     unscorable for one reason, both arms on one version, an arm split across
+     versions, or the arms look inverted
 
 Every question of the form "is this even an experiment?" is answered BEFORE any
 verdict that would reject, because a REJECT tells the reader to write the change
@@ -301,14 +319,20 @@ def classify_run(row):
 def score_repo(key, info):
     rec = {
         "repo": display[key], "entry": key, "wave": info["wave"],
-        "pair": info["pair"], "status": None, "why": None, "before": None,
+        "pair": info["pair"], "status": None, "why": None, "why_code": None,
+        "before": None,
         "after": None, "budget": None, "closure": None, "no_loss": None,
         "skill_version": None, "ts": None, "file": None, "other_files": 0,
         "gates": [], "unverified": [],
     }
+    # why_code is the machine-readable twin of `why`, which interpolates repo
+    # detail and so cannot be compared across repos. The systematic-defect check
+    # below groups on it: twelve repos unscorable for twelve different reasons is
+    # a cohort problem, and twelve unscorable for ONE reason is a gate problem.
     if info["status"] != "ok":
         rec["status"] = "unscorable"
         rec["why"] = info["status"]
+        rec["why_code"] = info["status"].replace(" ", "_")
         return rec
     # ts is a date, so several runs on one day tie. sorted() is stable, so ties
     # keep ledger order — which is append order, which is the true sequence.
@@ -316,6 +340,7 @@ def score_repo(key, info):
     if not rows:
         rec["status"] = "unscorable"
         rec["why"] = "no ledger rows"
+        rec["why_code"] = "no_ledger_rows"
         return rec
 
     # PRIMARY POLICY FILE: the one with the most rows, ties broken by whichever
@@ -355,6 +380,7 @@ def score_repo(key, info):
             rec["status"] = "unscorable"
             rec["why"] = ("the first attributed run carries no action tags, so it "
                           "cannot be told from a baseline; tag it and re-score")
+            rec["why_code"] = "untagged_run"
             return rec
         scored, scored_idx = r, i
         break
@@ -364,6 +390,7 @@ def score_repo(key, info):
         rec["status"] = "unscorable"
         rec["why"] = (f"no attributed curation run for {primary} yet (only "
                       f"baselines, or no skill_version){extra}")
+        rec["why_code"] = "no_attributed_run"
         return rec
 
     # The before-state is the row before it in the SAME file — carried from the
@@ -413,15 +440,18 @@ def score_repo(key, info):
     if prev is None:
         rec["status"] = "unscorable"
         rec["why"] = "no row before the first curation, so there is no before-state"
+        rec["why_code"] = "no_before_state"
         return rec
     if prev.get("tokens_exact") != scored.get("tokens_exact"):
         rec["status"] = "unscorable"
         rec["why"] = "measurement method changed at the scored run"
+        rec["why_code"] = "method_changed"
         return rec
     if not isinstance(prev.get("tokens"), int) or not isinstance(rec["after"], int) \
             or not isinstance(rec["budget"], int):
         rec["status"] = "unscorable"
         rec["why"] = "a token count or budget is missing"
+        rec["why_code"] = "missing_counts"
         return rec
 
     rec["before"] = prev["tokens"]
@@ -485,6 +515,51 @@ for pid in sorted(set(by_arm[treatment]) | set(by_arm[control]),
 
 informative = [p for p in pairs if p["informative"]]
 wins = [p for p in informative if p["winner"] == "treatment"]
+
+# An ADOPT and a REJECT are not symmetric outputs, so they do not share a floor.
+# An ADOPT is a decision to ship, revisited every time the skill changes again; a
+# REJECT writes into rejected-changes.md, which is permanent by design and shapes
+# every future proposal. Experiment 1 came within one flag of writing a rejection
+# from two pairs, both of them the honest-shortfall repos and one of them the pair
+# the roster itself flags as its weakest match. --min-pairs governs adoption and
+# can be lowered; the rejection floor cannot go below REJECT_FLOOR, whatever it is
+# set to. Below that a failed sweep is INCONCLUSIVE — pending evidence, which is
+# what it actually is.
+#
+# The SAFETY veto is deliberately not subject to this: a single repo that dropped
+# content rejects on its own with no pairs at all, which is why the t_failures
+# branch sits above the pair arithmetic and why arm() is wider than the pairing.
+REJECT_FLOOR = 3
+reject_floor = max(min_pairs, REJECT_FLOOR)
+
+# A systematic unscorable — every repo in BOTH arms blocked by one rule. See the
+# verdict branch below for why this is separated from "no informative pairs".
+SYSTEMIC_HINTS = {
+    "no_before_state":
+        "every scored run is a FIRST curation, and a first curation is the run "
+        "that creates the ledger. Record the Phase 1 measurement as a baseline "
+        "row — `record-telemetry.sh --baseline` — so each run carries the "
+        "before-state it is scored against (#116).",
+    "untagged_run":
+        "re-run Phase 7 with --actions naming what each run did; an untagged "
+        "row cannot be told from a baseline.",
+    "method_changed":
+        "supply a credential and re-measure with --exact rather than recording "
+        "estimates against exact rows.",
+}
+
+arm_records = [r for r in records if r["wave"] in (treatment, control)]
+systemic = systemic_hint = None
+if arm_records and all(r["status"] == "unscorable" for r in arm_records):
+    codes = {r["why_code"] for r in arm_records}
+    if len(codes) == 1:
+        code_one = next(iter(codes))
+        # Prefer the sentence when every repo produced the same one; fall back to
+        # the code when `why` interpolates per-repo detail (a file name, a count)
+        # and quoting one repo's version would misreport it as everyone's.
+        whys = {r["why"] for r in arm_records}
+        systemic = next(iter(whys)) if len(whys) == 1 else code_one
+        systemic_hint = SYSTEMIC_HINTS.get(code_one)
 
 
 def arm(wave, status):
@@ -653,6 +728,28 @@ elif t_unverified:
     reasons.append("safety could not be verified in the treatment arm: "
                    + "; ".join(f"{r['repo']} ({r['why']})" for r in t_unverified)
                    + " — re-run those curations with --no-loss and re-score")
+elif systemic is not None:
+    # A SYSTEMATIC unscorable is a defect in the gate, not an empty experiment,
+    # and the two read identically from below: both arrive at "no informative
+    # pairs", which sends the reader to look at pair scoring. Experiment 1 came
+    # back with all twelve repos unscorable for one reason — the before-state is
+    # the previous ledger row, and a first curation is the run that creates the
+    # ledger (#116) — and the only visible signal was the same line repeated
+    # twelve times above a verdict that reads as "nothing has happened yet".
+    #
+    # The test is deliberately strict: every repo in BOTH arms, one reason. A
+    # mixed bag of reasons is cohort non-compliance and each repo needs its own
+    # fix; one reason across both arms is a rule that no repo can satisfy.
+    verdict, code = "INCONCLUSIVE", 5
+    reasons.append(
+        f"GATE DEFECT — all {len(arm_records)} repos in both arms are unscorable "
+        f"for the SAME reason: {systemic}")
+    reasons.append(
+        "a rule no repo in either arm can satisfy is a defect in this gate, not "
+        "a finding about the cohort. Nothing was measured, so nothing about the "
+        "proposal is in question — fix the gate and re-score")
+    if systemic_hint:
+        reasons.append(systemic_hint)
 elif not informative:
     # Independent of --min-pairs. With --min-pairs 0 the sweep test below reads
     # `0 == 0` and adopts on no evidence whatever — a vacuous pass in the one
@@ -675,11 +772,25 @@ elif len(wins) == len(informative):
     reasons.append(f"the treatment won all {len(informative)} informative pairs "
                    f"(p={p:.3f}, one-sided sign test){caveat}")
 else:
-    verdict, code = "REJECT", 3
     lost = [f"pair {p['pair']} -> {p['winner']}" for p in informative
             if p["winner"] != "treatment"]
-    reasons.append(f"the treatment won {len(wins)} of {len(informative)} "
-                   f"informative pairs; adoption requires all ({'; '.join(lost)})")
+    shortfall = (f"the treatment won {len(wins)} of {len(informative)} "
+                 f"informative pairs; adoption requires all ({'; '.join(lost)})")
+    if len(informative) < reject_floor:
+        # Blocks adoption exactly as a rejection would, but does not write one
+        # down. See REJECT_FLOOR above: the asymmetry is between a decision that
+        # gets revisited and a record that does not.
+        verdict, code = "INCONCLUSIVE", 5
+        reasons.append(shortfall)
+        reasons.append(
+            f"but {len(informative)} informative pair(s) is below the rejection "
+            f"floor of {reject_floor}, so this is not recorded as a refutation. "
+            "A rejection is permanent and shapes every later proposal; adoption "
+            "is revisited the next time the skill changes, so the two do not "
+            "share a floor. The proposal is blocked and still pending evidence")
+    else:
+        verdict, code = "REJECT", 3
+        reasons.append(shortfall)
 
 # Only when inversion is what actually stopped the run. A split arm also trips
 # the older-than test — an incoherent arm compares older than anything — and
@@ -698,7 +809,9 @@ if fmt == "json":
         "treatment_versions": t_versions, "control_versions": c_versions,
         "repos": records, "pairs": pairs,
         "informative_pairs": len(informative), "treatment_wins": len(wins),
-        "min_pairs": min_pairs, "verdict": verdict, "reasons": reasons,
+        "min_pairs": min_pairs, "reject_floor": reject_floor,
+        "systemic_unscorable": systemic,
+        "verdict": verdict, "reasons": reasons,
         "treatment_arm_failures": [r["repo"] for r in t_failures],
         "treatment_arm_unverified": [r["repo"] for r in t_unverified],
         "control_arm_failures": [r["repo"] for r in c_failures],

--- a/skills/curating-context/scripts/score-cohort.sh
+++ b/skills/curating-context/scripts/score-cohort.sh
@@ -530,6 +530,11 @@ wins = [p for p in informative if p["winner"] == "treatment"]
 # content rejects on its own with no pairs at all, which is why the t_failures
 # branch sits above the pair arithmetic and why arm() is wider than the pairing.
 REJECT_FLOOR = 3
+# The EFFECTIVE floor, for reporting: --min-pairs gates every verdict first, so
+# when it is set above REJECT_FLOOR it is what a rejection actually has to clear.
+# The branch below is reachable only when min_pairs < REJECT_FLOOR — above that,
+# `len(informative) >= min_pairs >= REJECT_FLOOR` and the shortfall test cannot
+# fire — so REJECT_FLOOR is the constant that does the work there.
 reject_floor = max(min_pairs, REJECT_FLOOR)
 
 # A systematic unscorable — every repo in BOTH arms blocked by one rule. See the
@@ -548,9 +553,17 @@ SYSTEMIC_HINTS = {
         "estimates against exact rows.",
 }
 
-arm_records = [r for r in records if r["wave"] in (treatment, control)]
+# Every record IS in an arm: the shell layer diverts entries whose wave is
+# neither into out_of_arm before they reach here, so there is nothing to filter.
+arm_records = records
+# "No repo in either arm can satisfy this rule" is an inference from BREADTH, and
+# at two repos it is not supported — the likelier reading is two non-compliant
+# repos, which is a finding about the cohort and needs a different fix. Require
+# at least two per arm before naming a defect in the gate.
+SYSTEMIC_MIN = 4
 systemic = systemic_hint = None
-if arm_records and all(r["status"] == "unscorable" for r in arm_records):
+if len(arm_records) >= SYSTEMIC_MIN \
+        and all(r["status"] == "unscorable" for r in arm_records):
     codes = {r["why_code"] for r in arm_records}
     if len(codes) == 1:
         code_one = next(iter(codes))
@@ -776,7 +789,7 @@ else:
             if p["winner"] != "treatment"]
     shortfall = (f"the treatment won {len(wins)} of {len(informative)} "
                  f"informative pairs; adoption requires all ({'; '.join(lost)})")
-    if len(informative) < reject_floor:
+    if len(informative) < REJECT_FLOOR:
         # Blocks adoption exactly as a rejection would, but does not write one
         # down. See REJECT_FLOOR above: the asymmetry is between a decision that
         # gets revisited and a record that does not.
@@ -784,7 +797,7 @@ else:
         reasons.append(shortfall)
         reasons.append(
             f"but {len(informative)} informative pair(s) is below the rejection "
-            f"floor of {reject_floor}, so this is not recorded as a refutation. "
+            f"floor of {REJECT_FLOOR}, so this is not recorded as a refutation. "
             "A rejection is permanent and shapes every later proposal; adoption "
             "is revisited the next time the skill changes, so the two do not "
             "share a floor. The proposal is blocked and still pending evidence")

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -1615,7 +1615,9 @@ class TestCohortReportSingleFile:
         # AGENTS.md never moved: 9000 both times. Against sub/AGENTS.md's 500 it
         # would read +8500.
         assert cells["net"] == "0", cells
-        assert cells["runs"] == "2", cells
+        # One curation on AGENTS.md. `runs` counts curations, not rows, so
+        # neither its own baseline nor sub/AGENTS.md's row is in this number.
+        assert cells["runs"] == "1", cells
 
 
 def _two_file_ledger(root: Path, name: str, version: str,
@@ -1677,7 +1679,9 @@ class TestValidationGateRoundSeven:
         gate_rec = json.loads(gate.stdout)["repos"][0]
         assert gate_rec["file"] == "AGENTS.md"
         assert int(cells["tokens"]) == gate_rec["after"] == 7000
-        assert int(cells["runs"]) == 2      # AGENTS.md rows only
+        # One curation on AGENTS.md. Counting every file's curations would
+        # read 2 — sub/AGENTS.md was pruned too.
+        assert int(cells["runs"]) == 1
 
     def test_uncurated_primary_file_names_the_file_and_the_others(
             self, tmp_path: Path):
@@ -1777,7 +1781,7 @@ class TestValidationGateRoundEight:
         """Most-recent-file alone was too fragile: one incidental baseline row
         for docs/GUIDE.md re-defined a repo that had curated AGENTS.md over
         three runs, dropping it out of the experiment and collapsing the
-        roll-up's headline to 4,000 tokens / 1 run / no net — a number that then
+        roll-up's headline to 4,000 tokens / no runs / no net — a number that then
         fed the cohort total. Row count is what a stray append cannot flip."""
         d = tmp_path / "one" / ".skills"
         d.mkdir(parents=True)
@@ -1808,7 +1812,9 @@ class TestValidationGateRoundEight:
         cells = dict(zip(*(line.split("\t")
                            for line in rollup.stdout.splitlines()[:2])))
         assert cells["tokens"] == "6800", cells
-        assert cells["runs"] == "3", cells
+        # Two curations on AGENTS.md, plus a baseline. Scored off the stray
+        # docs/GUIDE.md row this would read 0 runs.
+        assert cells["runs"] == "2", cells
         assert cells["net"] == "-43200", cells
 
     def test_ties_on_row_count_fall_back_to_most_recent(self, tmp_path: Path):
@@ -1951,7 +1957,8 @@ class TestValidationGateRoundNine:
         assert len(payload["pairs"]) == 1
 
     def test_rollup_does_not_double_count_a_repeated_entry(self, tmp_path: Path):
-        """The same duplication inflated `runs` to 4 for a two-row ledger."""
+        """The same duplication inflated `runs` to 4 for a two-row ledger —
+        which is one curation, so the number to hold is 1."""
         _arm(tmp_path, "one", 50000, 20000, "1.1")
         path = tmp_path / "cohort"
         path.write_text(f"{tmp_path / 'one'}\n{tmp_path / 'one'}\n")
@@ -1961,7 +1968,7 @@ class TestValidationGateRoundNine:
         )
         cells = dict(zip(*(line.split("\t")
                            for line in r.stdout.splitlines()[:2])))
-        assert cells["runs"] == "2", cells
+        assert cells["runs"] == "1", cells
 
     @pytest.mark.parametrize("a,b", [("1.2", "v1.2"), ("v1.2", "1.2"),
                                      ("1.2", "1.2.0"), ("V1.2.0", "1.2")])
@@ -2583,8 +2590,9 @@ class TestBaselineRow:
         r = self._record(repo, self._measure(repo), "--baseline", *extra)
         assert r.returncode == 1, r.stderr
         assert marker in r.stderr
-        assert not (repo / ".skills" / "context-metrics.jsonl").exists() or \
-            self._rows(repo) == []
+        # The refusal lands before the ledger is created, so nothing was written
+        # at all — not even an empty file.
+        assert not (repo / ".skills" / "context-metrics.jsonl").exists()
 
     def test_pure_measurement_fields_are_still_allowed(self, tmp_path: Path):
         """--seams on a baseline row measures the surface as found, which is a
@@ -2687,12 +2695,32 @@ class TestSystematicUnscorable:
     def test_mixed_reasons_are_not_a_gate_defect(self, tmp_path: Path):
         """Different reasons per repo means each repo needs its own fix. That is
         a finding about the cohort, and claiming a defect in the gate would send
-        the reader to the wrong file."""
+        the reader to the wrong file.
+
+        Four repos, so the roster clears SYSTEMIC_MIN and the ONLY thing keeping
+        this from reading as a defect is the mix of reasons."""
+        spec = []
+        for i in (1, 2):
+            self._no_baseline(tmp_path, f"ctl{i}", "1.2")
+            spec.append((f"ctl{i}", "a", str(i)))
+        # No curation row at all — a different unscorable reason.
+        _arm(tmp_path, "trt1", 49000, None, "1.3")
+        self._no_baseline(tmp_path, "trt2", "1.3")
+        spec += [("trt1", "b", "1"), ("trt2", "b", "2")]
+        r = _score(_roster(tmp_path, spec), "--min-pairs", "1")
+        assert "GATE DEFECT" not in r.stdout, r.stdout
+
+    def test_two_repos_are_too_few_to_name_a_gate_defect(self, tmp_path: Path):
+        """The claim is an inference from BREADTH. At one repo per arm the
+        likelier reading is two non-compliant repos, which needs a different fix
+        than 'the gate is broken' — so the diagnosis stays off."""
         self._no_baseline(tmp_path, "ctl1", "1.2")
-        _arm(tmp_path, "trt1", 49000, None, "1.3")   # no curation row at all
+        self._no_baseline(tmp_path, "trt1", "1.3")
         r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
                    "--min-pairs", "1")
+        assert r.returncode == 5, r.stdout
         assert "GATE DEFECT" not in r.stdout, r.stdout
+        assert "no informative pairs" in r.stdout
 
 
 class TestRejectionFloor:
@@ -2739,3 +2767,76 @@ class TestRejectionFloor:
         assert r.returncode == 3, r.stdout
         assert "verdict: REJECT" in r.stdout
         assert "no_loss=failed" in r.stdout
+
+
+class TestRunsCountsCurationsNotRows:
+    """A curation run writes two rows — the Phase 1 baseline and the Phase 7
+    curation — so a row count reports every repo as having run twice as often as
+    it did. `runs` is the column a reader consults to answer "is this repo
+    actually running?", which is #118's whole subject."""
+
+    def _one_curation(self, root: Path) -> Path:
+        d = root / "one" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo="one", ts="2026-08-01", tokens=12000,
+                        actions=["baseline"]),
+            _ledger_row(repo="one", ts="2026-08-02", tokens=5800,
+                        actions=["demote:Big"], skill_version="1.4",
+                        no_loss="ok", delta_tokens=-6200),
+        ]) + "\n")
+        return root / "one"
+
+    def _rollup(self, repo: Path) -> dict:
+        r = subprocess.run(
+            ["bash", str(COHORT), "--local", str(repo), "--format", "tsv"],
+            capture_output=True, text=True, env=_clean_env(), timeout=30)
+        assert r.returncode == 0, r.stderr
+        head, row = (ln.split("\t") for ln in r.stdout.splitlines()[:2])
+        return dict(zip(head, row))
+
+    def test_one_curation_is_one_run(self, tmp_path: Path):
+        cells = self._rollup(self._one_curation(tmp_path))
+        assert cells["runs"] == "1", cells
+
+    def test_a_baseline_only_visit_is_zero_runs(self, tmp_path: Path):
+        """A run that measured and stopped. Before `runs` counted curations this
+        case had exactly one row, which is why the display keyed on `runs == 1`."""
+        d = tmp_path / "one" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text(_ledger_row(
+            repo="one", tokens=12000, actions=["baseline"]) + "\n")
+        cells = self._rollup(tmp_path / "one")
+        assert cells["runs"] == "0", cells
+        table = subprocess.run(
+            ["bash", str(COHORT), "--local", str(tmp_path / "one")],
+            capture_output=True, text=True, env=_clean_env(), timeout=30)
+        assert "(baseline only)" in table.stdout, table.stdout
+
+    def test_an_untagged_row_still_counts_as_a_run(self, tmp_path: Path):
+        """Only an explicit `baseline*` row is a state. An untagged row is a
+        tagging gap, and hiding it from the run count would hide the gap — the
+        same rule score-cohort.sh applies when it refuses to score one."""
+        d = tmp_path / "one" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo="one", ts="2026-08-01", tokens=12000,
+                        actions=["baseline"]),
+            _ledger_row(repo="one", ts="2026-08-02", tokens=9000, actions=[]),
+        ]) + "\n")
+        assert self._rollup(tmp_path / "one")["runs"] == "1"
+
+    def test_the_trend_reports_runs_and_rows_separately(self, tmp_path: Path):
+        repo = _repo(tmp_path, policy_lines=50)
+        measure = subprocess.run(
+            ["bash", str(MEASURE), "--no-write"], capture_output=True,
+            text=True, cwd=str(repo), env=_clean_env(), timeout=60).stdout
+        subprocess.run(["bash", str(RECORD), "--baseline"], input=measure,
+                       capture_output=True, text=True, cwd=str(repo),
+                       env=_clean_env(), timeout=30)
+        r = subprocess.run(
+            ["bash", str(RECORD), "--actions", "demote:Big", "--print-trend"],
+            input=measure, capture_output=True, text=True, cwd=str(repo),
+            env=_clean_env(), timeout=30)
+        assert r.returncode == 0, r.stderr
+        assert "1 run(s) over 2 rows" in r.stderr, r.stderr

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -1448,12 +1448,18 @@ class TestValidationGateRoundSix:
         _arm(tmp_path, "trt1", 49000, 9500, "1.2")
         r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
                    "--min-pairs", "1", "--format", "json")
-        ctl = next(x for x in json.loads(r.stdout)["repos"] if x["repo"] == "ctl1")
+        out = json.loads(r.stdout)
+        ctl = next(x for x in out["repos"] if x["repo"] == "ctl1")
         assert ctl["before"] == 50000, ctl
         # 50,000 -> 9,000 against a 6,000 budget is 93.2% closure, so the
         # control wins this pair and the treatment must not be adopted.
         assert round(ctl["closure"], 3) == round((44000 - 3000) / 44000, 3)
-        assert json.loads(r.stdout)["verdict"] == "REJECT"
+        # The pair outcome is what the fabricated before-state got wrong, so it
+        # is what this pins. The VERDICT is INCONCLUSIVE rather than REJECT only
+        # because one pair is below the rejection floor — a separate rule, with
+        # its own test.
+        assert out["pairs"][0]["winner"] == "control", out["pairs"]
+        assert out["verdict"] != "ADOPT"
 
     def test_min_pairs_zero_is_refused(self, tmp_path: Path):
         """`--min-pairs 0` let the sweep test read `0 == 0` and adopt on no
@@ -1642,13 +1648,18 @@ class TestValidationGateRoundSeven:
         _two_file_ledger(tmp_path, "trt1", "1.2", main_after=9000, sub_after=8800)
         r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
                    "--min-pairs", "1", "--format", "json")
-        by = {x["repo"]: x for x in json.loads(r.stdout)["repos"]}
+        out = json.loads(r.stdout)
+        by = {x["repo"]: x for x in out["repos"]}
         assert by["ctl1"]["file"] == "AGENTS.md", by["ctl1"]
         assert by["ctl1"]["before"] == 50000
         assert by["ctl1"]["after"] == 7000
         assert by["trt1"]["after"] == 9000
         # The control did the better job on the primary file, so no adoption.
-        assert json.loads(r.stdout)["verdict"] == "REJECT"
+        # Scored off sub/AGENTS.md the pair went the other way, which is the
+        # regression this pins; the verdict is INCONCLUSIVE rather than REJECT
+        # because one pair is below the rejection floor.
+        assert out["pairs"][0]["winner"] == "control", out["pairs"]
+        assert out["verdict"] != "ADOPT"
 
     def test_gate_and_rollup_agree_on_which_file_a_repo_is(self, tmp_path: Path):
         """One ledger produced two irreconcilable pictures of the same repo.
@@ -2497,3 +2508,234 @@ class TestRelativeInvocationFromSubdir:
         assert r.returncode in ok_codes, (
             f"{script}: exit {r.returncode}\n{r.stdout}\n{r.stderr}")
         assert "_context-lib.sh not found" not in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# The before-state a first curation never had (#116), and the rejection floor
+# a permanent record deserves (#117)
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineRow:
+    """`record-telemetry.sh --baseline` is what makes a FIRST curation scorable.
+
+    Experiment 1 scored nothing: the gate takes a run's before-state from the
+    previous ledger row, and a first curation is the run that CREATES the
+    ledger, so the scored run was exactly the run that could never be scored.
+    Twelve repos followed the skill correctly and produced twelve unscorable
+    rows."""
+
+    def _measure(self, repo: Path) -> str:
+        r = subprocess.run(
+            ["bash", str(MEASURE), "--no-write"], capture_output=True,
+            text=True, cwd=str(repo), env=_clean_env(), timeout=60)
+        assert r.returncode == 0, r.stderr
+        return r.stdout
+
+    def _record(self, repo: Path, measurement: str, *extra: str):
+        return subprocess.run(
+            ["bash", str(RECORD), *extra], input=measurement,
+            capture_output=True, text=True, cwd=str(repo), env=_clean_env(),
+            timeout=30)
+
+    def _rows(self, repo: Path) -> list[dict]:
+        return [json.loads(ln) for ln
+                in (repo / ".skills" / "context-metrics.jsonl").read_text()
+                .splitlines() if ln.strip()]
+
+    def test_baseline_row_is_tagged_and_measurement_only(self, tmp_path: Path):
+        repo = _repo(tmp_path, policy_lines=50)
+        r = self._record(repo, self._measure(repo), "--baseline")
+        assert r.returncode == 0, r.stderr
+        row = self._rows(repo)[-1]
+        # The tag the gate already knows to skip past, so a baseline row can
+        # never be mistaken for the curation it precedes.
+        assert row["actions"] == ["baseline"], row
+        assert row["no_loss"] is None
+        assert row["delta_tokens"] is None
+        assert "baseline" in r.stderr
+
+    def test_the_curation_row_then_has_a_before_state(self, tmp_path: Path):
+        """The whole point: Phase 1 and Phase 7 leave two rows, and the second
+        one has something to be compared against."""
+        repo = _repo(tmp_path, policy_lines=50)
+        assert self._record(repo, self._measure(repo), "--baseline").returncode == 0
+        (repo / "AGENTS.md").write_text(POLICY_LINE * 10)
+        r = self._record(repo, self._measure(repo), "--actions", "demote:Big",
+                         "--no-loss", "ok")
+        assert r.returncode == 0, r.stderr
+        rows = self._rows(repo)
+        assert len(rows) == 2
+        assert rows[0]["actions"] == ["baseline"]
+        assert isinstance(rows[1]["delta_tokens"], int)
+        assert rows[1]["delta_tokens"] < 0, rows[1]
+
+    @pytest.mark.parametrize("extra,marker", [
+        (("--actions", "demote:X"), "--baseline and --actions"),
+        (("--no-loss", "ok"), "--baseline and --no-loss"),
+    ])
+    def test_flags_that_assert_a_curation_are_refused(
+            self, tmp_path: Path, extra, marker):
+        """A baseline row records the surface AS FOUND. --no-loss in particular
+        would put a relocation verdict on a row where nothing was relocated, and
+        the gate reads that field as evidence."""
+        repo = _repo(tmp_path, policy_lines=50)
+        r = self._record(repo, self._measure(repo), "--baseline", *extra)
+        assert r.returncode == 1, r.stderr
+        assert marker in r.stderr
+        assert not (repo / ".skills" / "context-metrics.jsonl").exists() or \
+            self._rows(repo) == []
+
+    def test_pure_measurement_fields_are_still_allowed(self, tmp_path: Path):
+        """--seams on a baseline row measures the surface as found, which is a
+        before-state like any other and the one #117 argues the next experiment
+        turns on. Not refused."""
+        repo = _repo(tmp_path, policy_lines=50)
+        r = self._record(repo, self._measure(repo), "--baseline",
+                         "--seams", "41", "--seams-acked", "9")
+        assert r.returncode == 0, r.stderr
+        assert self._rows(repo)[-1]["seams"] == 41
+
+
+class TestFirstCurationIsScorable:
+    """With a baseline row the gate scores a first curation — and the orphan
+    gate, which needs a before-row to compare against, can trip at all."""
+
+    def _first_curation(self, root: Path, name: str, before: int, after: int,
+                        version: str, **kw) -> None:
+        d = root / name / ".skills"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo=name, ts="2026-08-01", tokens=before,
+                        actions=["baseline"],
+                        docs_orphaned=kw.get("orph_before", 0)),
+            _ledger_row(repo=name, ts="2026-08-02", tokens=after,
+                        actions=["demote:Big"], skill_version=version,
+                        no_loss=kw.get("no_loss", "ok"),
+                        docs_orphaned=kw.get("orph_after", 0)),
+        ]) + "\n")
+
+    def test_a_first_curation_scores(self, tmp_path: Path):
+        self._first_curation(tmp_path, "ctl1", 52000, 20000, "1.1")
+        self._first_curation(tmp_path, "trt1", 49000, 12000, "1.2")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1", "--format", "json")
+        out = json.loads(r.stdout)
+        by = {x["repo"]: x for x in out["repos"]}
+        assert by["trt1"]["status"] == "scored", by["trt1"]
+        assert by["trt1"]["before"] == 49000
+        assert out["pairs"][0]["informative"] is True
+        assert out["pairs"][0]["winner"] == "treatment"
+
+    def test_the_orphan_gate_can_now_trip_on_a_first_curation(
+            self, tmp_path: Path):
+        """Without a before-row `prev is None`, so the docs_orphaned comparison
+        was skipped entirely — one of the three safety gates was structurally
+        inert on the modal case."""
+        self._first_curation(tmp_path, "ctl1", 52000, 20000, "1.1")
+        self._first_curation(tmp_path, "trt1", 49000, 12000, "1.2",
+                             orph_before=0, orph_after=4)
+        roster = _roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")])
+        r = _score(roster, "--min-pairs", "1")
+        assert r.returncode == 3, r.stdout
+        assert "verdict: REJECT" in r.stdout
+        assert "docs_orphaned 0->4" in r.stdout
+
+        # The contrast, and the actual defect: strip the baseline rows and the
+        # same orphaning run sails through, because there is nothing to compare
+        # `docs_orphaned` against. This is the state all twelve first curations
+        # were scored in.
+        for name in ("ctl1", "trt1"):
+            led = tmp_path / name / ".skills" / "context-metrics.jsonl"
+            led.write_text(led.read_text().splitlines()[1] + "\n")
+        r = _score(roster, "--min-pairs", "1")
+        assert "docs_orphaned" not in r.stdout, r.stdout
+        assert "verdict: REJECT" not in r.stdout
+
+
+class TestSystematicUnscorable:
+    """Twelve repos unscorable for twelve reasons is cohort non-compliance.
+    Twelve unscorable for ONE reason is a rule no repo can satisfy, and the two
+    read identically from below — both arrive at 'no informative pairs'."""
+
+    def _no_baseline(self, root: Path, name: str, version: str) -> None:
+        """A first curation exactly as the skill produced it before #116: one
+        row, no predecessor."""
+        d = root / name / ".skills"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "context-metrics.jsonl").write_text(_ledger_row(
+            repo=name, tokens=5900, actions=["demote:Big"],
+            skill_version=version, no_loss="ok") + "\n")
+
+    def test_one_shared_reason_is_reported_as_a_gate_defect(self, tmp_path: Path):
+        spec = []
+        for i in (1, 2, 3):
+            self._no_baseline(tmp_path, f"ctl{i}", "1.2")
+            self._no_baseline(tmp_path, f"trt{i}", "1.3")
+            spec += [(f"ctl{i}", "a", str(i)), (f"trt{i}", "b", str(i))]
+        r = _score(_roster(tmp_path, spec), "--min-pairs", "1")
+        assert r.returncode == 5, r.stdout
+        assert "GATE DEFECT" in r.stdout, r.stdout
+        assert "all 6 repos in both arms" in r.stdout
+        assert "no row before the first curation" in r.stdout
+        # And it names the fix, rather than leaving the reader to walk the
+        # scoring core the way experiment 1 required.
+        assert "--baseline" in r.stdout
+        # The reason is stated ONCE as a diagnosis, not implied by repetition.
+        assert "no informative pairs" not in r.stdout
+
+    def test_mixed_reasons_are_not_a_gate_defect(self, tmp_path: Path):
+        """Different reasons per repo means each repo needs its own fix. That is
+        a finding about the cohort, and claiming a defect in the gate would send
+        the reader to the wrong file."""
+        self._no_baseline(tmp_path, "ctl1", "1.2")
+        _arm(tmp_path, "trt1", 49000, None, "1.3")   # no curation row at all
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1")
+        assert "GATE DEFECT" not in r.stdout, r.stdout
+
+
+class TestRejectionFloor:
+    """An adoption is revisited the next time the skill changes. A rejection is
+    written into rejected-changes.md permanently and shapes every later
+    proposal, so the two do not share a floor. Experiment 1 came within one flag
+    of rejecting v1.3 on two pairs."""
+
+    def _two_pairs_one_lost(self, root: Path) -> Path:
+        # Pair 1 to the treatment, pair 2 to the control.
+        _arm(root, "ctl1", 52000, 20000, "1.1")
+        _arm(root, "trt1", 49000, 12000, "1.2")
+        _arm(root, "ctl2", 28000, 12000, "1.1")
+        _arm(root, "trt2", 26000, 20000, "1.2")
+        return _roster(root, [("ctl1", "a", "1"), ("trt1", "b", "1"),
+                              ("ctl2", "a", "2"), ("trt2", "b", "2")])
+
+    def test_two_pairs_cannot_reject(self, tmp_path: Path):
+        r = _score(self._two_pairs_one_lost(tmp_path), "--min-pairs", "2")
+        assert r.returncode == 5, r.stdout
+        assert "verdict: INCONCLUSIVE" in r.stdout
+        assert "below the rejection floor" in r.stdout
+        # Still blocked, and still not written down as refuted.
+        assert "verdict: ADOPT" not in r.stdout
+        assert "record this in references/rejected-changes.md" not in r.stdout
+
+    def test_three_pairs_still_reject(self, tmp_path: Path):
+        """The floor bounds a rejection, it does not abolish one."""
+        roster = _three_good_pairs(tmp_path)
+        _arm(tmp_path, "trt3", 14000, 13000, "1.2")
+        r = _score(roster)
+        assert r.returncode == 3, r.stdout
+        assert "verdict: REJECT" in r.stdout
+        assert "below the rejection floor" not in r.stdout
+
+    def test_a_safety_failure_rejects_on_one_repo(self, tmp_path: Path):
+        """The veto is exempt. Content lost under the proposed version is lost
+        whether or not that repo had a partner, so a single repo rejects on its
+        own with no informative pairs at all."""
+        _arm(tmp_path, "ctl1", 52000, 20000, "1.1")
+        _arm(tmp_path, "trt1", 49000, 12000, "1.2", no_loss="failed")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1")
+        assert r.returncode == 3, r.stdout
+        assert "verdict: REJECT" in r.stdout
+        assert "no_loss=failed" in r.stdout

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -2722,6 +2722,20 @@ class TestSystematicUnscorable:
         assert "GATE DEFECT" not in r.stdout, r.stdout
         assert "no informative pairs" in r.stdout
 
+    def test_a_lopsided_roster_does_not_clear_the_floor(self, tmp_path: Path):
+        """Counted PER ARM, not over the roster. Three treatment repos and one
+        control clears a roster total of four while saying nothing about whether
+        the rule is satisfiable — one arm carrying a single repo is the same thin
+        evidence the floor exists to refuse."""
+        spec = []
+        for i in (1, 2, 3):
+            self._no_baseline(tmp_path, f"trt{i}", "1.3")
+            spec.append((f"trt{i}", "b", str(i)))
+        self._no_baseline(tmp_path, "ctl1", "1.2")
+        spec.append(("ctl1", "a", "1"))
+        r = _score(_roster(tmp_path, spec), "--min-pairs", "1")
+        assert "GATE DEFECT" not in r.stdout, r.stdout
+
 
 class TestRejectionFloor:
     """An adoption is revisited the next time the skill changes. A rejection is
@@ -2739,13 +2753,29 @@ class TestRejectionFloor:
                               ("ctl2", "a", "2"), ("trt2", "b", "2")])
 
     def test_two_pairs_cannot_reject(self, tmp_path: Path):
-        r = _score(self._two_pairs_one_lost(tmp_path), "--min-pairs", "2")
+        roster = self._two_pairs_one_lost(tmp_path)
+        r = _score(roster, "--min-pairs", "2")
         assert r.returncode == 5, r.stdout
         assert "verdict: INCONCLUSIVE" in r.stdout
         assert "below the rejection floor" in r.stdout
         # Still blocked, and still not written down as refuted.
         assert "verdict: ADOPT" not in r.stdout
         assert "record this in references/rejected-changes.md" not in r.stdout
+        # The floor a rejection had to clear, on the row, so a reader of the
+        # JSON can see why an INCONCLUSIVE is not a REJECT.
+        out = json.loads(_score(roster, "--min-pairs", "2",
+                                "--format", "json").stdout)
+        assert out["reject_floor"] == 3, out
+        assert out["informative_pairs"] == 2, out
+
+    def test_min_pairs_above_the_floor_is_the_effective_floor(self, tmp_path: Path):
+        """--min-pairs gates every verdict first, so when it is set higher it is
+        what a rejection actually has to clear. The JSON reports that, while the
+        branch below uses the constant."""
+        out = json.loads(_score(self._two_pairs_one_lost(tmp_path),
+                                "--min-pairs", "5", "--format", "json").stdout)
+        assert out["reject_floor"] == 5, out
+        assert out["verdict"] == "INCONCLUSIVE"
 
     def test_three_pairs_still_reject(self, tmp_path: Path):
         """The floor bounds a rejection, it does not abolish one."""
@@ -2839,4 +2869,108 @@ class TestRunsCountsCurationsNotRows:
             input=measure, capture_output=True, text=True, cwd=str(repo),
             env=_clean_env(), timeout=30)
         assert r.returncode == 0, r.stderr
-        assert "1 run(s) over 2 rows" in r.stderr, r.stderr
+        assert "1 run over 2 rows" in r.stderr, r.stderr
+
+
+class TestCurationRuleIsOneRule:
+    """Three scripts decide independently whether a ledger row records a RUN or
+    a state — score-cohort.sh's classify_run(), cohort-report.sh's and
+    record-telemetry.sh's is_curation_row(). Each comment says the rule must
+    stay identical; this is what makes that true rather than asserted.
+
+    The precedent is the neighbouring primary-file rule, which diverged between
+    the first two of these and produced two irreconcilable pictures of one repo:
+    the gate scoring a 100-token prune while the roll-up reported a
+    43,000-token curation."""
+
+    #  1  baseline            state  — plain tag
+    #  2  baseline:exact      state  — qualified tag, same prefix
+    #  3  demote:Big          RUN
+    #  4  (untagged)          RUN    — a tagging gap, not a measurement
+    # Every row carries skill_version, so a script that mistook a baseline for a
+    # curation would score row 1 rather than skipping to row 3.
+    def _mixed_ledger(self, root: Path, name: str, exact: bool = True) -> Path:
+        d = root / name / ".skills"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo=name, ts="2026-08-01", tokens=52000,
+                        tokens_exact=exact, actions=["baseline"],
+                        skill_version="1.4"),
+            _ledger_row(repo=name, ts="2026-08-02", tokens=50000,
+                        tokens_exact=exact, actions=["baseline:exact"],
+                        skill_version="1.4"),
+            _ledger_row(repo=name, ts="2026-08-03", tokens=7000,
+                        tokens_exact=exact, actions=["demote:Big"],
+                        skill_version="1.4", no_loss="ok"),
+            _ledger_row(repo=name, ts="2026-08-04", tokens=6900,
+                        tokens_exact=exact, actions=[], skill_version="1.4"),
+        ]) + "\n")
+        return root / name
+
+    def test_the_rollup_sees_two_runs(self, tmp_path: Path):
+        r = subprocess.run(
+            ["bash", str(COHORT), "--local", str(self._mixed_ledger(tmp_path, "one")),
+             "--format", "tsv"],
+            capture_output=True, text=True, env=_clean_env(), timeout=30)
+        assert r.returncode == 0, r.stderr
+        cells = dict(zip(*(ln.split("\t") for ln in r.stdout.splitlines()[:2])))
+        # 4 if baselines counted, 1 if the untagged row did not.
+        assert cells["runs"] == "2", cells
+
+    def test_the_gate_skips_both_baselines_to_the_curation(self, tmp_path: Path):
+        """Row 3 is the scored run and row 2 is its before-state. A script that
+        read `baseline`/`baseline:exact` as curations would stop at row 1, which
+        has no predecessor, and report the repo unscorable instead."""
+        self._mixed_ledger(tmp_path, "ctl1")
+        _arm(tmp_path, "trt1", 49000, 12000, "1.5")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1", "--format", "json")
+        rec = next(x for x in json.loads(r.stdout)["repos"] if x["repo"] == "ctl1")
+        assert rec["status"] == "scored", rec
+        assert rec["before"] == 50000 and rec["after"] == 7000, rec
+
+    def test_the_gate_still_refuses_an_untagged_run_it_reaches_first(
+            self, tmp_path: Path):
+        """The other half of the rule: an untagged row counts as a run, and when
+        it is the FIRST run it cannot be told from a baseline, so the gate says
+        so rather than scoring it. Same classification, opposite consequence."""
+        d = tmp_path / "ctl1" / ".skills"
+        d.mkdir(parents=True)
+        (d / "context-metrics.jsonl").write_text("\n".join([
+            _ledger_row(repo="ctl1", ts="2026-08-01", tokens=52000,
+                        actions=["baseline"], skill_version="1.4"),
+            _ledger_row(repo="ctl1", ts="2026-08-02", tokens=7000, actions=[],
+                        skill_version="1.4"),
+        ]) + "\n")
+        _arm(tmp_path, "trt1", 49000, 12000, "1.5")
+        r = _score(_roster(tmp_path, [("ctl1", "a", "1"), ("trt1", "b", "1")]),
+                   "--min-pairs", "1", "--format", "json")
+        rec = next(x for x in json.loads(r.stdout)["repos"] if x["repo"] == "ctl1")
+        assert rec["why_code"] == "untagged_run", rec
+
+    def test_the_trend_header_sees_the_same_two_runs(self, tmp_path: Path):
+        """Recorded through the script itself, so the third copy of the rule is
+        exercised rather than read."""
+        repo = _repo(tmp_path, policy_lines=50)
+        self._mixed_ledger(tmp_path, "repo", exact=False)
+        measure = subprocess.run(
+            ["bash", str(MEASURE), "--no-write"], capture_output=True,
+            text=True, cwd=str(repo), env=_clean_env(), timeout=60).stdout
+        r = subprocess.run(
+            ["bash", str(RECORD), "--actions", "prune:X", "--print-trend"],
+            input=measure, capture_output=True, text=True, cwd=str(repo),
+            env=_clean_env(), timeout=30)
+        assert r.returncode == 0, r.stderr
+        # Two runs in the fixture plus the one just recorded, over five rows.
+        assert "3 runs over 5 rows" in r.stderr, r.stderr
+
+    def test_a_baseline_only_trend_reads_grammatically(self, tmp_path: Path):
+        repo = _repo(tmp_path, policy_lines=50)
+        measure = subprocess.run(
+            ["bash", str(MEASURE), "--no-write"], capture_output=True,
+            text=True, cwd=str(repo), env=_clean_env(), timeout=60).stdout
+        r = subprocess.run(
+            ["bash", str(RECORD), "--baseline", "--print-trend"], input=measure,
+            capture_output=True, text=True, cwd=str(repo), env=_clean_env(),
+            timeout=30)
+        assert "0 runs over 1 row" in r.stderr, r.stderr


### PR DESCRIPTION
Closes #116. Implements #117's proposal 4.

## The defect

The validation gate takes a run's before-state from the previous ledger row for
the same file, and a first curation is the run that *creates* the ledger. The
scored run was exactly the run that could never be scored — all twelve cohort
repos came back `unscorable` in experiment 1, having followed the skill
correctly.

The same absence disarmed a safety gate, which the issue did not name:
`docs_orphaned` trips on a *rise* against the previous row, so with no previous
row it could not trip at all. The recorded values were `0`, so nothing was missed
in fact, but the check had not run on any of the twelve.

## The fix

`record-telemetry.sh --baseline` appends a measurement-only row tagged
`baseline` — the tag every reader already skips past — and Phase 1 now writes it.
Both rows ship in one commit. The tag is fixed rather than taken from
`--actions`, and `--no-loss` is refused, so a row can never claim a relocation
verdict for edits that had not happened yet. `--seams`/`--seams-acked` are
allowed: a sweep of the surface as found is a before-state too, and the one #117
argues the next experiment turns on.

Chosen over the issue's proposed `tokens_before` field, which fixes the token
axis only — the orphan gate needs `docs_orphaned` before, #117 needs `seams`
before, #118 lists two more. A baseline row restores the before-state for every
field at once, and every consumer was already built for it (`classify_run` skips
`baseline*`, the tag vocabulary documents it, the roll-up has a `(baseline only)`
state).

The issue's proposal 2 (`--baseline-file`) was **not** built: it cannot produce a
verdict, because #117 shows the metric is blind to what v1.3 changed, and it
carries the integrity hazard its own paragraph describes. The hand-scored table
stays frozen in `validation-gate.md` as the experiment record.

## Riding along

- **Systematic unscorable is a gate defect** (#116 proposal 3). Every repo in
  both arms blocked by one reason now prints the reason once, names the fix, and
  says it is a defect in the gate — instead of twelve identical lines under "no
  informative pairs", which reads as "nothing has happened yet". Requires two
  repos per arm; one arm carrying a single repo says nothing about whether the
  rule is satisfiable.
- **A REJECT needs three informative pairs** whatever `--min-pairs` says (#117
  proposal 4). An adoption is revisited the next time the skill changes; a
  rejection is written into `rejected-changes.md` permanently. At `--min-pairs 2`
  experiment 1 would have rejected v1.3 on two repos, both honest-shortfall cases
  and one the roster's weakest-matched pair. The safety veto stays exempt — one
  repo that dropped content rejects on its own.
- **`runs` counts curations, not rows.** A run now writes two rows, so the
  roll-up and `--print-trend` were reporting every repo as having run twice as
  often as it did — the column a reader consults to answer "is this cohort
  running?", which is #118's whole subject.

## Verification

- 1298 passed, 27 skipped; `shellcheck -S warning` clean on all changed scripts.
- The orphan-gate test asserts the contrast both ways: an orphaning run is
  REJECTed with baseline rows present, and sails through with them stripped.
- The row-vs-state rule now lives in three scripts. `TestCurationRuleIsOneRule`
  feeds one mixed ledger through all three; verified by mutating each
  implementation in turn — each mutation fails its own test.

## Not recovered

Experiment 1. The cohort's first-curation capital is spent either way — that is
#118, which is in scope and not yet started. This makes the *next* run of the
gate measure something.

Skill version 1.3 → 1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
