### PR TITLE
#126 fix: measure-context.sh reads the budget knob the other surfaces read

### DIFF
--- a/skills/curating-context/SKILL.md
+++ b/skills/curating-context/SKILL.md
@@ -4,7 +4,7 @@ description: Curates a repo's agent-context surface — AGENTS.md and the refere
 compatibility: Designed for Claude (claude.ai, Claude Code, or similar). Requires git, bash, and python3. Optionally uses gh for issue verification and the cohort roll-up, and ANTHROPIC_API_KEY for exact token counts.
 metadata:
   author: gregoryfoster
-  version: "1.5"
+  version: "1.6"
   triggers: curate context, context budget, hone AGENTS.md, trim AGENTS.md, prune context
 ---
 
@@ -100,9 +100,14 @@ variable — each Bash invocation runs in a fresh shell.
 
 `scripts/` also holds **`_context-lib.sh`**, which is sourced rather than run.
 `measure-context.sh`, `context-budget-guard.sh`, and `context-delta.sh` all read
-the bytes-per-token ratio, the archival matcher, the docs-dir knob, and the
-symlink/git comparison from it, so the weekly run and both continuous surfaces
-cannot disagree about a number. It must travel with them: vendor the whole
+the bytes-per-token ratio, the archival matcher, the docs-dir knob, **the two
+budgets**, and the symlink/git comparison from it, so the weekly run and both
+continuous surfaces cannot disagree about a number. The budgets were the
+exception until [#126](https://github.com/gregoryfoster/skills/issues/126):
+`measure-context.sh` hardcoded 6,000 and read only its flag, so a repo that set
+`.skills/context-budget` got warnings at its own number from both continuous
+surfaces and **ledger rows recorded against 6,000** — the denominator
+`score-cohort.sh` divides by. It must travel with them: vendor the whole
 `scripts/` directory, never individual files. `install-guard.sh` refuses to
 install a guard whose library is missing, because that combination wires up
 cleanly and then does nothing, silently.

--- a/skills/curating-context/references/budget-and-metrics.md
+++ b/skills/curating-context/references/budget-and-metrics.md
@@ -73,6 +73,16 @@ and record why, rather than failing every week.
 Override per repo with `--budget` / `--doc-budget`, or inline via the trigger
 phrase (`context budget 6000`).
 
+**One chain, four scripts.** Every reader resolves the budget the same way —
+the flag, then `CONTEXT_BUDGET`, then `.skills/context-budget`, then 6,000 — and
+the per-doc budget likewise via `CONTEXT_DOC_BUDGET` and
+`.skills/context-doc-budget`. `install-guard.sh --budget N` writes the knob file,
+which is what makes a repo's choice stick across the weekly measurement, the
+write guard and the review delta. `measure-context.sh` was the exception and
+recorded every row against 6,000 regardless
+([#126](https://github.com/gregoryfoster/skills/issues/126)); a test now pins all
+three surfaces to one answer for one knob file.
+
 ## Measuring tokens
 
 `measure-context.sh --exact` calls `POST /v1/messages/count_tokens`. That endpoint

--- a/skills/curating-context/references/cadence.md
+++ b/skills/curating-context/references/cadence.md
@@ -294,12 +294,6 @@ by it rather than assumed to be per-week.
   budget into a merge gate is [#88](https://github.com/gregoryfoster/skills/issues/88),
   and its sequencing rule stands: add the gate per repo only *after* that repo is
   under budget, or it is a permanently-red check people learn to bypass.
-- **Its drift warning inherits [#126](https://github.com/gregoryfoster/skills/issues/126).**
-  `measure-context.sh` hardcodes the 6,000 budget and does not read
-  `.skills/context-budget`, though the write guard and the review delta both do.
-  A repo that set a custom budget gets warned — and gets a `budget` field on
-  every row — against 6,000 instead. Latent today, since the whole cohort runs
-  the default; live the moment somebody runs `install-guard.sh --budget N`.
 - **It does not fix the arms problem.** Rows carry `skill_version`, so a series
   can still be split by version — but the confounds
   [#118](https://github.com/gregoryfoster/skills/issues/118) names (version

--- a/skills/curating-context/scripts/measure-context.sh
+++ b/skills/curating-context/scripts/measure-context.sh
@@ -20,8 +20,13 @@ Options:
                      .skills/context-docs-dir, then docs. The write guard and
                      context-delta.sh read the same knob, so setting it once
                      keeps all three looking at the same tree.
-  --budget N         Token budget for the policy file (default 6000).
-  --doc-budget N     Token budget per reference doc (default 10000).
+  --budget N         Token budget for the policy file. Overrides CONTEXT_BUDGET
+                     and .skills/context-budget; default 6000. The knob file is
+                     what install-guard.sh --budget writes, and what the write
+                     guard and the review delta read, so all three agree.
+  --doc-budget N     Token budget per reference doc. Same chain via
+                     CONTEXT_DOC_BUDGET and .skills/context-doc-budget;
+                     default 10000.
   --archival NAMES   Space-separated <docs-dir> subdirectory names treated as an
                      archive rather than live context: excluded from the doc
                      inventory, and not traversed for links. Default:
@@ -92,8 +97,11 @@ USAGE
 
 POLICY=""
 DOCS_DIR=""
-BUDGET=6000
-DOC_BUDGET=10000
+# Resolved AFTER the library loads, through the same override -> env -> knob
+# file -> default chain the write guard and the review delta use. These hold
+# only the flag.
+BUDGET_OVERRIDE=""
+DOC_BUDGET_OVERRIDE=""
 ARCHIVAL="plans specs research audits archive"
 EXACT=0
 CHECK_CRED=0
@@ -113,8 +121,8 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --file) POLICY="${2:?--file needs a path}"; shift 2 ;;
     --docs-dir) DOCS_DIR="${2:?--docs-dir needs a path}"; shift 2 ;;
-    --budget) BUDGET="${2:?--budget needs a number}"; shift 2 ;;
-    --doc-budget) DOC_BUDGET="${2:?--doc-budget needs a number}"; shift 2 ;;
+    --budget) BUDGET_OVERRIDE="${2:?--budget needs a number}"; shift 2 ;;
+    --doc-budget) DOC_BUDGET_OVERRIDE="${2:?--doc-budget needs a number}"; shift 2 ;;
     --archival) need_arg "$#" --archival 'pass "" to measure everything'
                 ARCHIVAL="$2"; shift 2 ;;
     --exact) EXACT=1; shift ;;
@@ -159,6 +167,20 @@ _libdir="$(cd "$(dirname "$_self")" 2>/dev/null && pwd -P)" || _libdir=""
 # fallback to cwd covers running outside a git repo at all.
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$ROOT" || { echo "ERROR cannot cd to $ROOT" >&2; exit 2; }
+
+# The budgets, through the SAME chain as context-budget-guard.sh and
+# context-delta.sh: flag, then CONTEXT_BUDGET, then .skills/context-budget, then
+# the default. This script used to hardcode 6000 and read the flag only, so the
+# two continuous surfaces honoured a repo's configured budget and the WEEKLY
+# MEASUREMENT did not — and it is this script that puts `budget` and
+# `over_budget` on the ledger row, which score-cohort.sh divides by and #118
+# proposes as the adherence metric. install-guard.sh --budget writes that knob,
+# so the supported way to configure a budget was the one that produced the
+# disagreement (#126).
+BUDGET="$(ctx_read_num_knob "$BUDGET_OVERRIDE" "${CONTEXT_BUDGET-}" \
+  "$ROOT/.skills/context-budget" 6000)"
+DOC_BUDGET="$(ctx_read_num_knob "$DOC_BUDGET_OVERRIDE" "${CONTEXT_DOC_BUDGET-}" \
+  "$ROOT/.skills/context-doc-budget" 10000)"
 
 # --check-credential: answer "will --exact succeed?" BEFORE a run commits to
 # eight phases of work. Same three sources as the real resolution below, same

--- a/skills/curating-context/scripts/measure-context.sh
+++ b/skills/curating-context/scripts/measure-context.sh
@@ -137,6 +137,23 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# Digits only, checked HERE rather than left to the resolver. ctx_read_num_knob
+# returns the fallback for anything it cannot parse, which is right for a knob
+# FILE — a repo should not fail to measure because someone left a comment in one
+# — and wrong for a FLAG, where a typo is the likely cause and silence means the
+# run measures against 6000 and records that. Before #126 a malformed --budget
+# at least produced `[: 4,000: integer expression expected` on stderr; losing
+# that would be a step in the direction this change exists to reverse.
+for _pair in "--budget=$BUDGET_OVERRIDE" "--doc-budget=$DOC_BUDGET_OVERRIDE"; do
+  _flag="${_pair%%=*}"; _val="${_pair#*=}"
+  case "$_val" in
+    '') ;;
+    *[!0-9]*)
+      echo "ERROR $_flag must be a non-negative integer (got '$_val')" >&2
+      exit 1 ;;
+  esac
+done
+
 # --- shared library -------------------------------------------------------
 # Resolve through a symlink chain first: this script may be reached through a
 # symlinked vendor tree, and ${BASH_SOURCE[0]}'s dirname would then hold no

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -3446,3 +3446,88 @@ class TestCadenceDescribesTheRepoNotTheInvocation:
         assert "merge=union" not in text, text
         # And our explanatory comments went with the line they explained.
         assert "Append-only telemetry" not in text, text
+
+
+class TestBudgetKnobIsOneAnswer:
+    """The budget was resolved through the shared library by
+    context-budget-guard.sh and context-delta.sh, and HARDCODED at 6000 by
+    measure-context.sh — which is the script that puts `budget` and
+    `over_budget` on the ledger row, the denominator score-cohort.sh divides by
+    and the field #118 proposes as the adherence metric.
+
+    So a repo configuring a budget got warnings at N from two surfaces and rows
+    recorded against 6000 forever, and `install-guard.sh --budget` — the
+    documented way to set it — was what produced the disagreement (#126)."""
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        repo = _repo(tmp_path, policy_lines=100)
+        (repo / ".skills").mkdir()
+        (repo / ".skills" / "context-budget").write_text("200\n")
+        return repo
+
+    def _measured(self, repo: Path, *args: str, env: dict | None = None) -> dict:
+        r = subprocess.run(
+            ["bash", str(MEASURE), "--no-write", *args], capture_output=True,
+            text=True, cwd=str(repo), env={**_clean_env(), **(env or {})},
+            timeout=60)
+        assert r.returncode == 0, r.stderr
+        return json.loads(r.stdout)["policy"]
+
+    def test_the_row_is_measured_against_the_configured_budget(self, repo: Path):
+        p = self._measured(repo)
+        assert p["budget"] == 200, p
+        assert p["over_budget"] is True, p
+
+    def test_all_three_surfaces_agree_on_one_knob(self, repo: Path):
+        """The pin. One knob file, one answer, across every script that reads a
+        budget — the same shape as TestCurationRuleIsOneRule and for the same
+        reason: this is the third rule duplicated across these scripts."""
+        assert self._measured(repo)["budget"] == 200
+
+        # The guard and the delta both report on GROWTH against HEAD, so the
+        # edit has to be real for either to speak.
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", "seed")
+        (repo / "AGENTS.md").write_text(POLICY_LINE * 300)
+
+        guard = _advisory(_run_guard(repo, repo / "AGENTS.md"))
+        assert guard is not None, "guard stayed silent on an over-budget policy"
+        assert "200 budget" in guard, guard
+
+        delta = subprocess.run(
+            ["bash", str(DELTA)], capture_output=True, text=True,
+            cwd=str(repo), env=_clean_env(), timeout=60).stdout
+        # The delta prints a table; read the budget column off the AGENTS.md row
+        # rather than substring-matching a number that appears in several.
+        row = next(ln for ln in delta.splitlines() if ln.startswith("AGENTS.md"))
+        assert row.split()[3] == "200", row
+        assert "OVER" in row, row
+
+    @pytest.mark.parametrize("args,env,expected", [
+        ((), {}, 200),                                   # the knob file
+        ((), {"CONTEXT_BUDGET": "999"}, 999),            # env beats the file
+        (("--budget", "4242"), {"CONTEXT_BUDGET": "999"}, 4242),  # flag beats both
+    ])
+    def test_the_precedence_matches_the_other_surfaces(
+            self, repo: Path, args, env, expected):
+        assert self._measured(repo, *args, env=env)["budget"] == expected
+
+    def test_no_knob_still_defaults(self, tmp_path: Path):
+        """The flag stops being the only source without becoming optional."""
+        plain = _repo(tmp_path, policy_lines=100)
+        assert self._measured(plain)["budget"] == 6000
+
+    def test_the_doc_budget_reads_its_knob_too(self, tmp_path: Path):
+        repo = _repo(tmp_path, policy_lines=10)
+        (repo / ".skills").mkdir()
+        (repo / ".skills" / "context-doc-budget").write_text("300\n")
+        (repo / "docs").mkdir()
+        (repo / "docs" / "BIG.md").write_text(POLICY_LINE * 400)
+        r = subprocess.run(
+            ["bash", str(MEASURE), "--no-write"], capture_output=True, text=True,
+            cwd=str(repo), env=_clean_env(), timeout=60)
+        assert r.returncode == 0, r.stderr
+        docs = json.loads(r.stdout)["docs"]
+        big = next(d for d in docs if d["path"].endswith("BIG.md"))
+        assert big["over_budget"] is True, big

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -3500,8 +3500,13 @@ class TestBudgetKnobIsOneAnswer:
             cwd=str(repo), env=_clean_env(), timeout=60).stdout
         # The delta prints a table; read the budget column off the AGENTS.md row
         # rather than substring-matching a number that appears in several.
-        row = next(ln for ln in delta.splitlines() if ln.startswith("AGENTS.md"))
-        assert row.split()[3] == "200", row
+        lines = delta.splitlines()
+        # Locate the column from the HEADER rather than a fixed index, so a
+        # reordered table fails pointing at the table instead of at the budget.
+        header = next(ln for ln in lines if ln.split()[:2] == ["file", "tokens"])
+        col = header.split().index("budget")
+        row = next(ln for ln in lines if ln.startswith("AGENTS.md"))
+        assert row.split()[col] == "200", (header, row)
         assert "OVER" in row, row
 
     @pytest.mark.parametrize("args,env,expected", [
@@ -3518,16 +3523,38 @@ class TestBudgetKnobIsOneAnswer:
         plain = _repo(tmp_path, policy_lines=100)
         assert self._measured(plain)["budget"] == 6000
 
-    def test_the_doc_budget_reads_its_knob_too(self, tmp_path: Path):
+    @pytest.mark.parametrize("args,env,expected", [
+        ((), {}, 300),                                        # the knob file
+        ((), {"CONTEXT_DOC_BUDGET": "700"}, 700),              # env beats it
+        (("--doc-budget", "900"), {"CONTEXT_DOC_BUDGET": "700"}, 900),  # flag wins
+    ])
+    def test_the_doc_budget_has_the_same_three_rungs(
+            self, tmp_path: Path, args, env, expected):
+        """The less-used half, parametrised like the policy budget. The
+        asymmetry is where a copy-paste slip in the second ctx_read_num_knob
+        call would have hidden."""
         repo = _repo(tmp_path, policy_lines=10)
         (repo / ".skills").mkdir()
         (repo / ".skills" / "context-doc-budget").write_text("300\n")
         (repo / "docs").mkdir()
         (repo / "docs" / "BIG.md").write_text(POLICY_LINE * 400)
         r = subprocess.run(
-            ["bash", str(MEASURE), "--no-write"], capture_output=True, text=True,
-            cwd=str(repo), env=_clean_env(), timeout=60)
+            ["bash", str(MEASURE), "--no-write", *args], capture_output=True,
+            text=True, cwd=str(repo), env={**_clean_env(), **env}, timeout=60)
         assert r.returncode == 0, r.stderr
-        docs = json.loads(r.stdout)["docs"]
-        big = next(d for d in docs if d["path"].endswith("BIG.md"))
-        assert big["over_budget"] is True, big
+        out = json.loads(r.stdout)
+        big = next(d for d in out["docs"] if d["path"].endswith("BIG.md"))
+        # ~1000 tokens of doc: over 300 and 700, under 900.
+        assert big["over_budget"] is (big["tokens"] > expected), (expected, big)
+
+    @pytest.mark.parametrize("flag", ["--budget", "--doc-budget"])
+    def test_a_malformed_budget_flag_is_refused(self, tmp_path: Path, flag):
+        """ctx_read_num_knob returns the fallback for anything unparseable —
+        right for a knob file, wrong for a flag, where silence means the run
+        measures against 6000 and records that."""
+        r = subprocess.run(
+            ["bash", str(MEASURE), "--no-write", flag, "4,000"],
+            capture_output=True, text=True, cwd=str(_repo(tmp_path)),
+            env=_clean_env(), timeout=60)
+        assert r.returncode == 1, r.stdout
+        assert f"{flag} must be a non-negative integer (got '4,000')" in r.stderr


### PR DESCRIPTION
Closes #126.

## The asymmetry

`context-budget-guard.sh` and `context-delta.sh` both resolved the budget through
the shared library — flag, then `CONTEXT_BUDGET`, then `.skills/context-budget`,
then 6,000. `measure-context.sh` hardcoded 6,000 and read only its flag.

That is the script that puts `budget` and `over_budget` on the ledger row, so a
repo configuring a budget got warnings at its own number from two surfaces and
**rows recorded against 6,000 forever** — the denominator `score-cohort.sh`
divides by for closure, and the field #118 proposes as the adherence metric. And
`install-guard.sh --budget N` writes that knob, so the documented way to set a
budget was the one that produced the disagreement.

It also falsified a claim in `SKILL.md`: that the library is what keeps these
three from disagreeing about a number. They could, about this number.

## The fix

`--budget` / `--doc-budget` become the override argument rather than the only
source, which leaves every current invocation behaving identically. Verified
across all four rungs: knob `200` → 200, `CONTEXT_BUDGET=999` → 999,
`--budget 4242` → 4242, nothing → 6000.

`TestBudgetKnobIsOneAnswer` pins all three surfaces to one answer for one knob
file — the same shape as `TestCurationRuleIsOneRule`, and for the same reason:
this is the third rule duplicated across these scripts. Reverting the fix fails
four of its cases.

## Review found one thing worth knowing

The fix initially traded a loud failure for a silent one. `ctx_read_num_knob`
returns the fallback for anything it cannot parse, so `--budget 4,000` began
measuring against 6,000 and saying nothing — where the pre-fix script at least
printed `[: 4,000: integer expression expected`. That is right for a knob *file*
(a repo should not fail to measure because somebody annotated one) and wrong for
a *flag*, where a typo is the likely cause.

Flags are now validated at parse time, matching `record-telemetry.sh`'s
`--seams`. Mutation-verified.

## Filed, not fixed here

[#132](https://github.com/gregoryfoster/skills/issues/132) — the knob-file parser
uses `tr -dc '0-9'`, which deletes non-digits rather than parsing, so `v2 6000`
resolves to **26000**: a wrong number rather than no number, silently. Shared
library behaviour affecting all three surfaces, so it does not belong in this
branch.

## Latent, not live

No cohort repo sets the knob today, so no recorded row is wrong. That was luck,
and it would have expired the moment the weekly cadence started writing rows —
which it now does, one per repo per week.

1340 passed, 27 skipped. Skill version 1.5 → 1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
