### PR TITLE
fix: bump the cadence template to actions/checkout@v5 (#163)

### DIFF
--- a/.github/workflows/context-cadence.yml
+++ b/.github/workflows/context-cadence.yml
@@ -45,7 +45,11 @@ jobs:
       # fetch-depth: 0 because the push path rebases when a human commit lands
       # during the measurement, and rebasing on a depth-1 clone lacks the history
       # to replay onto.
-      - uses: actions/checkout@v4
+      # @v5, not @v4: v4 targets Node 20, which runners now force onto Node 24
+      # with a deprecation warning on every run. Twelve repos are about to adopt
+      # this template, and sweeping twelve for a warning we could have not
+      # written is the avoidable version of the problem (#163).
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0

--- a/skills/curating-context/references/cadence.md
+++ b/skills/curating-context/references/cadence.md
@@ -162,7 +162,11 @@ jobs:
       # fetch-depth: 0 because the push path rebases when a human commit lands
       # during the measurement, and rebasing on a depth-1 clone lacks the history
       # to replay onto.
-      - uses: actions/checkout@v4
+      # @v5, not @v4: v4 targets Node 20, which runners now force onto Node 24
+      # with a deprecation warning on every run. Twelve repos are about to adopt
+      # this template, and sweeping twelve for a warning we could have not
+      # written is the avoidable version of the problem (#163).
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0

--- a/skills/curating-context/scripts/install-cadence.sh
+++ b/skills/curating-context/scripts/install-cadence.sh
@@ -325,7 +325,11 @@ jobs:
       # fetch-depth: 0 because the push path rebases when a human commit lands
       # during the measurement, and rebasing on a depth-1 clone lacks the history
       # to replay onto.
-      - uses: actions/checkout@v4
+      # @v5, not @v4: v4 targets Node 20, which runners now force onto Node 24
+      # with a deprecation warning on every run. Twelve repos are about to adopt
+      # this template, and sweeping twelve for a warning we could have not
+      # written is the avoidable version of the problem (#163).
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 0


### PR DESCRIPTION
Follow-up to #165, before the cohort adopts this template (#163).

The first dogfooded run went green but logged:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`

Twelve repos are about to adopt this template. Writing the warning into all twelve and then sweeping all twelve to remove it is the avoidable version of the problem, so it goes now.

Three files, because the template has three copies by design:

- `scripts/install-cadence.sh` — the renderer
- `references/cadence.md` — the annotated block, which `TestCadenceTemplateMatchesTheRenderer` pins **byte-for-byte** against `--print`
- `.github/workflows/context-cadence.yml` — this repo's rendered copy, regenerated by re-running the installer

That test caught a first attempt where the doc comment was worded differently from the script comment. Working as designed — it is the pin for what its docstring calls "the third copy-divergence in this skill."

Re-running the installer reported `updated:` and rewrote in place, which exercises the update path that had not run anywhere before — #165 only proved the fresh-install and no-op paths.

`pytest tests/structural/` — 2201 passed, 127 skipped.

Merging this then re-dispatching, to confirm `@v5` still records a row before the pilot repo takes the template.

Out of scope: `actions/checkout@v4` also appears in `init-project-fastapi/references/github-ci.md` and `vendoring-openapi-client/references/live-drift.md`. Different skills, different adoption paths — a sweep for those belongs in its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
