### PR TITLE
fix: ship install-refresh.sh, and make the doctor report a half-installed hook (#167)

### DIFF
--- a/skills/managing-skills/SKILL.md
+++ b/skills/managing-skills/SKILL.md
@@ -160,80 +160,38 @@ Pulls upstream submodule changes once per calendar day, on `main` only, and auto
 - **Commits the doctor it installed** ([#86](https://github.com/gregoryfoster/skills/issues/86)). The install is a working-tree repair and runs on every branch; the commit stays behind the `main`-only and once-per-day gates. Without this the hook wrote a file nothing ever tracked — four of twelve audited consumers had been reinstalling an untracked doctor for weeks, so their fresh worktrees and CI clones had none and the Phase 1 preflight silently short-circuited.
 - To verify the hook is running, check `.git/skills-update.log` after a session start on `main`. Lines beginning `unexpected hook error` come from the ERR-trap backstop and mark an unanticipated failure path; the hook still exits 0.
 
-#### Step 0 — Skip if already installed
-
-Re-runs of `/managing-skills` must never double-wire the hook. Bail out of the procedure if **both** of these are already true:
-
-- The symlink at `.claude/hooks/skills-submodule-update.sh` exists and resolves to the vendored script (`../../skills-vendor/<owner>-<repo>/skills/managing-skills/scripts/skills-submodule-update.sh`).
-- `.claude/settings.json` contains the string `.claude/hooks/skills-submodule-update.sh` at least once. Match the script path, not the whole command — an install written before the `$CLAUDE_PROJECT_DIR` form ([#110](https://github.com/gregoryfoster/skills/issues/110)) uses a cwd-relative command and must still be recognised.
-
-Otherwise — fresh install or partial install — continue. Steps 1 and 2 are individually idempotent (`ln -sf` and a jq merge that dedupes the entry first), so they repair partial state without creating duplicates.
-
-#### Step 1 — Symlink the hook script
-
-Install via **symlink**, not copy, so upstream fixes to the script propagate via the normal submodule refresh. Use `-f` so a re-run replaces an existing symlink rather than failing:
+**Run the installer. Do not hand-execute the steps below.**
 
 ```bash
-mkdir -p .claude/hooks
-ln -sf ../../skills-vendor/<owner>-<repo>/skills/managing-skills/scripts/skills-submodule-update.sh \
-   .claude/hooks/skills-submodule-update.sh
+bash skills-vendor/<owner>-<repo>/skills/managing-skills/scripts/install-refresh.sh
 ```
 
-The `../../` prefix resolves from `.claude/hooks/` back to the project root, then into the vendored script path.
+It is idempotent, repairs a partial install, and never commits. Check state without changing anything with `--check` (exit 0 both artifacts present, 3 either missing); remove both with `--uninstall`.
 
-#### Step 2 — Merge the hook into `.claude/settings.json`
+**The contract is TWO artifacts, and only the second one makes the hook run:**
 
-**Merge, don't overwrite.** If `.claude/settings.json` already has `hooks.SessionStart` entries, append to that array — never clobber the file. The jq expression below is defensive in two ways: it creates `.hooks` and `.hooks.SessionStart` if they don't exist, and it **strips any pre-existing entry for this hook before appending** so re-runs never produce duplicates. It works against an empty `{}`, a partial settings.json without a `hooks` block, a populated one with other hooks, and one where this hook is already present:
+1. `.claude/hooks/skills-submodule-update.sh` — a symlink into the vendor
+2. a `SessionStart` entry in `.claude/settings.json` — the registration
 
-```bash
-jq '(.hooks //= {}) |
-    (.hooks.SessionStart //= []) |
-    .hooks.SessionStart |= map(select(((.hooks // [])[0].command // "") | tostring | contains("skills-submodule-update.sh") | not)) |
-    .hooks.SessionStart += [{
-      "matcher": ".*",
-      "hooks": [{
-        "type": "command",
-        "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/skills-submodule-update.sh\""
-      }]
-    }]' .claude/settings.json > .claude/settings.json.tmp \
-  && mv .claude/settings.json.tmp .claude/settings.json
-```
+A repo carrying artifact 1 without artifact 2 looks installed to anyone who lists `.claude/hooks/` and refreshes nothing. Four of twelve audited consumers were in exactly that state — symlink present and tracked, registration absent — pinned at one commit for over a week while the rest of the cohort moved through four skill versions ([#167](https://github.com/gregoryfoster/skills/issues/167)). This procedure was prose and `install-doctor.sh` was a script, which is the only difference between them that predicts the failure population. `.skills/doctor.sh` now warns when it sees that half-installed state.
 
-Two details in that expression are load-bearing:
+<details>
+<summary>What the installer does — read this when debugging it, not to execute it</summary>
 
-- **The command is anchored on `$CLAUDE_PROJECT_DIR`**, not on the hook process's cwd ([#110](https://github.com/gregoryfoster/skills/issues/110)). Claude Code normally runs hooks from the project dir, so the older `bash .claude/hooks/…` form works today — but it is an undocumented assumption, and a repo whose `settings.json` mixes both styles is what made this visible in review. The `${CLAUDE_PROJECT_DIR:-.}` fallback is the same one `init-socraticode` uses: with the variable unset, a bare `"$CLAUDE_PROJECT_DIR/…"` degrades to `bash "/.claude/hooks/…"` and errors on every session start, where `.` degrades to exactly the old behaviour.
-- **The strip matches the script path, not the whole command string.** An equality test against the current command would skip an entry written in the older form — duplicating the hook here, and leaving it unremovable by the uninstall filter below.
+1. **Symlinks** rather than copies, so upstream fixes propagate through the normal submodule refresh. The target is relative and derived from the vendor directory actually found, not from a hand-substituted `<owner>-<repo>` — that substitution is how a symlink ends up pointing at a plausible path that does not exist.
+2. **Merges** `.claude/settings.json` with jq, dedupe-then-append: it creates `.hooks`/`.hooks.SessionStart` when absent, preserves every other hook and key, and strips any pre-existing entry for this hook first so a re-run cannot duplicate it.
 
-If `.claude/settings.json` does not exist yet, create it with `echo '{}' > .claude/settings.json` before running the jq command.
+Two details in that merge are load-bearing, and `install-refresh.sh` carries the full reasoning inline:
 
-The merged result should look like:
+- **The command is anchored on `$CLAUDE_PROJECT_DIR`**, not the hook process's cwd ([#110](https://github.com/gregoryfoster/skills/issues/110)). The `${CLAUDE_PROJECT_DIR:-.}` fallback matters: unset, a bare `"$CLAUDE_PROJECT_DIR/…"` becomes `bash "/.claude/hooks/…"` and errors on every session start, where `.` degrades to exactly the old behaviour.
+- **The strip matches the script path, not the whole command.** An equality test would skip an entry written in the older cwd-relative form — duplicating the hook, and leaving the original unremovable by the uninstall filter.
 
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": ".*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/skills-submodule-update.sh\""
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+</details>
 
-#### Step 3 — Commit
-
-```bash
-git add .claude/hooks/skills-submodule-update.sh .claude/settings.json
-git commit -m "chore: enable skills auto-refresh hook"
-```
 
 ### Uninstalling the auto-refresh hook
+
+`install-refresh.sh --uninstall` does both halves. The manual equivalent:
 
 Remove the symlink:
 

--- a/skills/managing-skills/scripts/doctor.sh
+++ b/skills/managing-skills/scripts/doctor.sh
@@ -42,7 +42,7 @@ set -euo pipefail
 # copy that produced it. Nothing branches on it: sync_self keeps the installed
 # copy equal to the vendored source, which makes drift transient and a
 # version-comparison mechanism unnecessary.
-VERSION="2026-08-11-1"
+VERSION="2026-08-14-1"
 
 CHECK_ONLY=0
 VERBOSE=0
@@ -191,6 +191,47 @@ sync_self() {
 # the overwhelming majority of invocations. A self-sync placed after the heal
 # logic would almost never run.
 sync_self
+
+# The auto-refresh hook's contract is TWO artifacts — the symlink and the
+# SessionStart registration in .claude/settings.json — and only the second one
+# makes it run. A repo carrying the symlink without the registration looks
+# installed to anyone who lists .claude/hooks/ and refreshes nothing, so its
+# vendored skills freeze at whatever commit they were on.
+#
+# Four of twelve audited consumers were in exactly that state, pinned at one
+# commit for over a week while the rest of the cohort moved through four skill
+# versions (#167). Nothing detected it, because a half-installed hook is silent
+# by construction: the missing half is the half that would have run.
+#
+# Reported HERE, for the same reason sync_self lives here — the doctor is the
+# one code path that still runs in a repo whose refresh hook does not, whether
+# through a reviewing-*/shipping-* preflight or a SessionStart entry of its
+# own. Warn only; a wiring gap is not a dangling symlink and must not change
+# this script's exit code, which Phase 1 preflights gate on with `|| exit 1`.
+#
+# Only when the symlink is present: that is what distinguishes "somebody
+# installed this and it half-landed" from "this consumer never wanted the
+# hook", and nagging the second group trains everyone to ignore the first.
+check_refresh_registration() {
+  local hook=".claude/hooks/skills-submodule-update.sh"
+  local settings=".claude/settings.json"
+  [ -L "$hook" ] || return 0
+  # Match the script path rather than the whole command: an install predating
+  # the $CLAUDE_PROJECT_DIR form (#110) is cwd-relative and still a real
+  # registration. grep, not jq — the doctor must not gain a jq dependency, and
+  # a missing jq making a present registration read as absent would turn this
+  # warning into noise on every session in every consumer without it.
+  if [ -f "$settings" ] && grep -q 'skills-submodule-update\.sh' "$settings"; then
+    return 0
+  fi
+  echo "doctor: $hook is installed but $settings does not register it," >&2
+  echo "doctor: so the auto-refresh hook never runs and this repo's vendored" >&2
+  echo "doctor: skills stay frozen at their current commit. Repair with:" >&2
+  echo "doctor:   bash skills-vendor/*/skills/managing-skills/scripts/install-refresh.sh" >&2
+  return 0
+}
+
+check_refresh_registration
 
 # Directories whose direct children are scanned for dangling symlinks.
 # skills/ is the vendored-skill chain; .claude/hooks/ holds the hook symlinks

--- a/skills/managing-skills/scripts/install-refresh.sh
+++ b/skills/managing-skills/scripts/install-refresh.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# install-refresh.sh — wire the skills auto-refresh hook into a consumer repo.
+#
+# The contract is TWO artifacts, and that is the whole reason this script
+# exists:
+#
+#   1. .claude/hooks/skills-submodule-update.sh   — a symlink into the vendor
+#   2. an entry in .claude/settings.json          — the SessionStart registration
+#
+# The symlink alone does nothing. Claude Code runs what settings.json names, so
+# a repo carrying artifact 1 without artifact 2 looks installed to anyone who
+# lists .claude/hooks/ and never refreshes anything. Four of twelve audited
+# consumers were in exactly that state — symlink present and tracked,
+# registration absent — pinned at one commit for over a week while the rest of
+# the cohort moved through four skill versions (#167).
+#
+# That was a hand-executed three-step procedure in SKILL.md. install-doctor.sh
+# has been a script since the beginning and has no comparable failure
+# population; the difference is not the operators, it is that one of the two
+# installs was a script and the other was prose. So this is the prose,
+# executed.
+#
+# Idempotent: a re-run repairs whichever half is missing and reports the other
+# unchanged. It never commits.
+set -euo pipefail
+
+HOOK_NAME="skills-submodule-update.sh"
+HOOK_REL=".claude/hooks/$HOOK_NAME"
+SETTINGS_REL=".claude/settings.json"
+
+usage() {
+  cat <<'USAGE'
+install-refresh.sh — install the skills auto-refresh SessionStart hook
+
+Usage:
+  bash <vendor>/skills/managing-skills/scripts/install-refresh.sh [options]
+
+Options:
+  --check      Report what is installed; change nothing. The contract is TWO
+               artifacts, so both are reported independently and the exit code
+               reflects either being absent.
+               Exit 0 both present, 3 either missing.
+  --uninstall  Remove the symlink AND the settings.json registration.
+  --quiet, -q  Suppress progress messages (errors and --check still print).
+  -h, --help   Show this help and exit 0.
+
+What it does:
+  Symlinks .claude/hooks/skills-submodule-update.sh at the vendored script, so
+  upstream fixes propagate through the normal submodule refresh rather than
+  needing a re-copy.
+
+  Merges a SessionStart entry into .claude/settings.json. The merge is
+  dedupe-then-append and matches on the SCRIPT PATH rather than the whole
+  command, so an entry written in the older cwd-relative form (pre-#110) is
+  recognised and replaced instead of duplicated.
+
+  Neither step clobbers unrelated content: other SessionStart hooks, other hook
+  events, and every other key in settings.json are preserved.
+
+Requires jq, which is what merges settings.json without rewriting it.
+
+It does not commit. Review the diff and commit with your normal gate:
+  git add .claude/hooks/skills-submodule-update.sh .claude/settings.json
+  git commit -m "chore: enable skills auto-refresh hook"
+
+Exit codes:
+  0  installed, repaired, unchanged, or uninstalled
+  1  usage error, not in a consumer repo, no vendored hook script, or no jq
+  3  --check only: one or both artifacts are missing
+USAGE
+}
+
+MODE="install"
+QUIET=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) MODE="check"; shift ;;
+    --uninstall) MODE="uninstall"; shift ;;
+    --quiet|-q) QUIET=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+log() { [ "$QUIET" = "1" ] || echo "install-refresh: $*"; }
+err() { echo "install-refresh: $*" >&2; }
+
+# The consumer root, not this script's location: the script lives inside the
+# vendor tree, and is invoked from the checkout it is operating on.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  err "not inside a git repository"; exit 1; }
+cd "$ROOT"
+
+HOOK="$ROOT/$HOOK_REL"
+SETTINGS="$ROOT/$SETTINGS_REL"
+
+# Registration test, shared by every mode so the reader and the writer cannot
+# drift — the lesson install-cadence.sh learned when its --check reported "yes"
+# against a line the installer no longer wrote.
+#
+# Matches the SCRIPT PATH, not the whole command, exactly as SKILL.md's Step 0
+# specifies: an install predating the $CLAUDE_PROJECT_DIR form (#110) uses a
+# cwd-relative command and is still a real registration. grep, not jq, because
+# this runs on the --check path in repos that may not have jq and a missing jq
+# must not make a present registration read as absent.
+is_registered() {
+  [ -f "$SETTINGS" ] || return 1
+  grep -q "$HOOK_NAME" "$SETTINGS"
+}
+
+# Registered AND in the current anchored form. The two are deliberately
+# different questions, because they answer to different callers:
+#
+#   is_registered  — "does this hook run at all?" A legacy cwd-relative entry
+#                    runs today, so --check must report it as installed and the
+#                    doctor must not nag about it. Reporting a working repo as
+#                    broken is how a warning gets ignored.
+#   is_current     — "is it in the form we now install?" The install path uses
+#                    this one, so a re-run UPGRADES a legacy entry instead of
+#                    seeing the substring, declaring victory, and leaving the
+#                    undocumented cwd assumption (#110) in place forever.
+#
+# Collapsing these into one test is what made a re-run a no-op on exactly the
+# repos that most needed it.
+is_current() {
+  [ -f "$SETTINGS" ] || return 1
+  # The literal ${CLAUDE_PROJECT_DIR:-.} is the text being searched FOR, not an
+  # expansion to perform — single quotes and -F are both the point. Expanding it
+  # here would search for the runner's own project dir and never match.
+  # shellcheck disable=SC2016
+  grep -qF '${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/'"$HOOK_NAME" "$SETTINGS"
+}
+
+# Resolves, not merely exists. A dangling symlink is the state doctor.sh exists
+# to repair, and reporting it as installed here would send an operator looking
+# anywhere but at the submodule.
+is_linked() {
+  [ -L "$HOOK" ] && [ -e "$HOOK" ]
+}
+
+if [ "$MODE" = "check" ]; then
+  # Reported independently. The two are separate failure modes — a symlink with
+  # no registration never runs, a registration with no symlink errors on every
+  # session start — and gating the second report on the first hides whichever
+  # one you were not looking for.
+  rc=0
+  if is_linked; then
+    echo "hook symlink:       $HOOK_REL -> $(readlink "$HOOK")"
+  elif [ -L "$HOOK" ]; then
+    echo "hook symlink:       DANGLING ($HOOK_REL) — run .skills/doctor.sh, or"
+    echo "                    git submodule update --init --recursive"
+    rc=3
+  else
+    echo "hook symlink:       MISSING ($HOOK_REL)"
+    rc=3
+  fi
+  if is_registered; then
+    echo "SessionStart entry: yes (in $SETTINGS_REL)"
+  elif [ -L "$HOOK" ]; then
+    # The half-installed state this script exists for. Say what it costs, not
+    # just what is absent — "MISSING" alone reads as cosmetic next to a symlink
+    # that is visibly right there.
+    echo "SessionStart entry: MISSING — the hook is on disk but Claude Code never"
+    echo "                    runs it, so this repo's vendored skills are frozen"
+    echo "                    at their current commit. Re-run install-refresh.sh."
+    rc=3
+  else
+    echo "SessionStart entry: MISSING ($SETTINGS_REL)"
+    rc=3
+  fi
+  exit "$rc"
+fi
+
+need_jq() {
+  command -v jq >/dev/null 2>&1 || {
+    err "jq is required to edit $SETTINGS_REL safely"
+    err "install jq, or follow the manual steps in managing-skills/SKILL.md"
+    exit 1; }
+}
+
+if [ "$MODE" = "uninstall" ]; then
+  if [ -L "$HOOK" ] || [ -e "$HOOK" ]; then
+    rm -f "$HOOK"
+    log "removed $HOOK_REL"
+  else
+    log "nothing to remove: no $HOOK_REL"
+  fi
+  if is_registered; then
+    need_jq
+    jq 'if .hooks.SessionStart then
+          .hooks.SessionStart |= map(select(((.hooks // [])[0].command // "")
+            | tostring | contains("skills-submodule-update.sh") | not))
+        else . end' "$SETTINGS" >"$SETTINGS.tmp" \
+      && mv -f "$SETTINGS.tmp" "$SETTINGS"
+    log "removed the SessionStart entry from $SETTINGS_REL"
+  fi
+  log "not committed — review and commit with your normal gate."
+  exit 0
+fi
+
+# --- install ---------------------------------------------------------------
+
+# First matching vendor wins, matching sync_self() in doctor.sh and the `break`
+# in skills-submodule-update.sh. When skills-vendor/ is absent the glob stays
+# unexpanded and the -f test rejects the literal string, so SRC stays empty and
+# the error below fires rather than a symlink being pointed at a path that
+# never existed.
+SRC=""
+for candidate in skills-vendor/*/skills/managing-skills/scripts/"$HOOK_NAME"; do
+  [ -f "$candidate" ] || continue
+  SRC="$candidate"
+  break
+done
+[ -n "$SRC" ] || {
+  err "no vendored $HOOK_NAME found under skills-vendor/*/skills/managing-skills/scripts/"
+  err "add the skills repo as a submodule first — see managing-skills/SKILL.md"
+  exit 1; }
+
+need_jq
+
+# Relative, and derived from the vendor directory that was actually found
+# rather than from a placeholder the caller was asked to substitute. The
+# <owner>-<repo> in SKILL.md's ln command is the kind of hand-substitution that
+# produces a symlink pointing at a plausible path which does not exist.
+# ../../ climbs out of .claude/hooks/ to the repo root.
+mkdir -p "$ROOT/.claude/hooks"
+TARGET="../../$SRC"
+if is_linked && [ "$(readlink "$HOOK")" = "$TARGET" ]; then
+  log "unchanged: $HOOK_REL already points at $SRC"
+else
+  # -f so a re-run replaces a stale or dangling symlink rather than failing.
+  ln -sfn "$TARGET" "$HOOK"
+  log "linked $HOOK_REL -> $SRC"
+fi
+
+[ -f "$SETTINGS" ] || { echo '{}' >"$SETTINGS"; log "created $SETTINGS_REL"; }
+
+if is_current; then
+  log "unchanged: $SETTINGS_REL already registers the hook"
+else
+  # An `if`, not `is_registered && log ...` — doctor.sh carries the same note:
+  # under set -e the && form leaves the statement's exit status at the failing
+  # test, and this one fails on every fresh install.
+  if is_registered; then
+    log "upgrading the registration to the \$CLAUDE_PROJECT_DIR form (#110)"
+  fi
+  # Defensive in the two ways SKILL.md documents: it creates .hooks and
+  # .hooks.SessionStart when absent, and it strips any pre-existing entry for
+  # this hook before appending so a re-run cannot produce duplicates.
+  #
+  # $CLAUDE_PROJECT_DIR, not the hook process's cwd (#110). Claude Code
+  # normally runs hooks from the project dir, so the bare form works today, but
+  # that is an undocumented assumption. The :-. fallback matters: with the
+  # variable unset a bare "$CLAUDE_PROJECT_DIR/..." becomes "/.claude/hooks/..."
+  # and errors on every session start, where "." degrades to the old behaviour.
+  jq '(.hooks //= {}) |
+      (.hooks.SessionStart //= []) |
+      .hooks.SessionStart |= map(select(((.hooks // [])[0].command // "")
+        | tostring | contains("skills-submodule-update.sh") | not)) |
+      .hooks.SessionStart += [{
+        "matcher": ".*",
+        "hooks": [{
+          "type": "command",
+          "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/skills-submodule-update.sh\""
+        }]
+      }]' "$SETTINGS" >"$SETTINGS.tmp" \
+    && mv -f "$SETTINGS.tmp" "$SETTINGS"
+  log "registered the SessionStart entry in $SETTINGS_REL"
+fi
+
+[ "$QUIET" = "1" ] || cat <<NEXT
+
+Not committed — review and commit with your normal gate. BOTH artifacts:
+  git add $HOOK_REL $SETTINGS_REL
+  git commit -m "chore: enable skills auto-refresh hook"
+
+The hook runs at most once per UTC day, on main only, and auto-commits the
+pointer bumps. To confirm it ran, check .git/skills-update.log after a session
+start on main.
+NEXT

--- a/tests/structural/test_guard_install_paths.py
+++ b/tests/structural/test_guard_install_paths.py
@@ -286,7 +286,33 @@ class TestGuardCommandForm:
 class TestManagingSkillsHookCommand:
     """#110's second and third installers. The documented jq snippets are run
     verbatim, because a removal filter that stops matching the old form is how
-    an existing install becomes unremovable."""
+    an existing install becomes unremovable.
+
+    The INSTALL half is now install-refresh.sh rather than a jq block in
+    SKILL.md (#167) — a hand-executed procedure left four of twelve consumers
+    half-installed — so these two run the script. The rule is unchanged and
+    still belongs here; only its implementation moved from prose to code. The
+    uninstall filter below is still documented prose and still run verbatim."""
+
+    def _consumer(self, tmp_path: Path) -> Path:
+        """A checkout install-refresh.sh will act on: a git repo with the hook
+        script vendored where the installer's glob looks for it."""
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True,
+                       env=_clean_env())
+        vendor = (tmp_path / "skills-vendor" / "acme-skills" / "skills"
+                  / "managing-skills" / "scripts")
+        vendor.mkdir(parents=True)
+        (vendor / "skills-submodule-update.sh").write_text(
+            (MS_SCRIPTS / "skills-submodule-update.sh").read_text())
+        return tmp_path
+
+    def _install(self, cwd: Path):
+        result = subprocess.run(
+            ["bash", str(MS_SCRIPTS / "install-refresh.sh"), "--quiet"],
+            capture_output=True, text=True, cwd=str(cwd), env=_clean_env(),
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
 
     def _fenced_blocks(self, text: str) -> list[str]:
         return re.findall(r"```(?:bash|json)\n(.*?)```", text, re.DOTALL)
@@ -330,17 +356,19 @@ class TestManagingSkillsHookCommand:
         assert result.returncode == 0, result.stdout + result.stderr
 
     @requires_jq
-    def test_documented_install_snippet_writes_the_anchored_command(self, tmp_path):
-        settings = self._seed(tmp_path, "bash unrelated-only.sh")
+    def test_the_installer_writes_the_anchored_command(self, tmp_path):
+        repo = self._consumer(tmp_path)
+        settings = self._seed(repo, "bash unrelated-only.sh")
         settings.write_text(json.dumps({}))
-        self._run_block(self._jq_block("SessionStart +="), tmp_path)
+        self._install(repo)
 
         assert self._session_commands(settings) == [UPDATE_COMMAND]
 
     @requires_jq
-    def test_documented_install_snippet_replaces_a_legacy_entry(self, tmp_path):
-        settings = self._seed(tmp_path, LEGACY_UPDATE_COMMAND)
-        self._run_block(self._jq_block("SessionStart +="), tmp_path)
+    def test_the_installer_replaces_a_legacy_entry(self, tmp_path):
+        repo = self._consumer(tmp_path)
+        settings = self._seed(repo, LEGACY_UPDATE_COMMAND)
+        self._install(repo)
 
         assert self._session_commands(settings) == [
             "bash unrelated.sh", UPDATE_COMMAND

--- a/tests/structural/test_refresh_hook_install.py
+++ b/tests/structural/test_refresh_hook_install.py
@@ -1,0 +1,334 @@
+"""Behavioral tests for install-refresh.sh and the doctor's half-install warning
+(issue #167).
+
+The auto-refresh hook's contract is TWO artifacts — the symlink at
+`.claude/hooks/skills-submodule-update.sh` and the SessionStart registration in
+`.claude/settings.json` — and only the second makes it run. Four of twelve
+audited consumers carried the first without the second: symlink present and
+tracked, registration absent, so nothing ever bumped their vendored pointer.
+All four sat at one commit for over a week while the cohort moved through four
+skill versions.
+
+Nothing detected it, because a half-installed hook is silent by construction —
+the missing half is the half that would have run. The install was also the only
+one of the pair that was prose rather than a script; `install-doctor.sh` has
+been a script since the beginning and has no comparable failure population.
+
+Run end-to-end against throwaway repos, because what matters is runtime
+behaviour on the exact broken state: whether a repair preserves the operator's
+other hooks and keys, and whether the doctor speaks up without changing its
+exit code.
+
+Coverage — install-refresh.sh:
+- virgin repo                                 → both artifacts installed
+- --check on a virgin repo                    → exit 3, both reported MISSING
+- --check when installed                      → exit 0
+- the #167 half-install                       → --check exit 3, symlink OK
+- repairing a half-install                    → preserves unrelated SessionStart
+                                                entries and unrelated top-level
+                                                keys
+- pre-existing entry in the old cwd-relative
+  form (#110)                                 → recognised, not duplicated
+- re-run                                      → idempotent, reports unchanged
+- dangling symlink                            → --check exit 3, reported as
+                                                DANGLING rather than installed
+- --uninstall                                 → removes both halves, leaves
+                                                other hooks intact
+- no skills-vendor/                           → exit 1, nothing written
+- not a git repo                              → exit 1
+- the symlink target is relative and resolves
+
+Coverage — doctor.sh:
+- half-installed hook   → warns, names install-refresh.sh, still exits 0
+- fully installed hook  → silent about the hook
+- no symlink at all     → silent (never nag a consumer that declined the hook)
+
+Keep this list current — it is the file's index.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = (
+    Path(__file__).resolve().parent.parent.parent
+    / "skills"
+    / "managing-skills"
+    / "scripts"
+)
+INSTALL_REFRESH = SCRIPTS / "install-refresh.sh"
+DOCTOR = SCRIPTS / "doctor.sh"
+HOOK_SRC = SCRIPTS / "skills-submodule-update.sh"
+
+VENDOR_REL = "skills-vendor/acme-skills/skills/managing-skills/scripts"
+HOOK_REL = ".claude/hooks/skills-submodule-update.sh"
+SETTINGS_REL = ".claude/settings.json"
+
+
+def _clean_env() -> dict:
+    """Env without inherited GIT_* vars — pre-commit sets GIT_INDEX_FILE etc.,
+    which would leak into the script's git calls."""
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _run(repo: Path, script: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(script), *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+        timeout=30,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A consumer checkout with the skill vendored but no hook wired."""
+    r = tmp_path / "consumer"
+    r.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=r, check=True, env=_clean_env())
+    vendor = r / VENDOR_REL
+    vendor.mkdir(parents=True)
+    (vendor / "skills-submodule-update.sh").write_text(HOOK_SRC.read_text())
+    return r
+
+
+def _half_install(repo: Path, settings: dict | None = None) -> None:
+    """The exact #167 state: symlink present, registration absent."""
+    hooks = repo / ".claude" / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    (hooks / "skills-submodule-update.sh").symlink_to(
+        Path("../..") / VENDOR_REL / "skills-submodule-update.sh"
+    )
+    if settings is not None:
+        (repo / SETTINGS_REL).write_text(json.dumps(settings))
+
+
+def _settings(repo: Path) -> dict:
+    return json.loads((repo / SETTINGS_REL).read_text())
+
+
+def _commands(repo: Path) -> list[str]:
+    entries = _settings(repo).get("hooks", {}).get("SessionStart", [])
+    return [h.get("command", "") for e in entries for h in e.get("hooks", [])]
+
+
+class TestInstallRefresh:
+    def test_a_virgin_repo_gets_both_artifacts(self, repo: Path):
+        r = _run(repo, INSTALL_REFRESH)
+        assert r.returncode == 0, r.stderr
+        assert (repo / HOOK_REL).is_symlink()
+        assert (repo / HOOK_REL).resolve().is_file()
+        assert any("skills-submodule-update.sh" in c for c in _commands(repo))
+
+    def test_check_on_a_virgin_repo_reports_both_missing(self, repo: Path):
+        r = _run(repo, INSTALL_REFRESH, "--check")
+        assert r.returncode == 3
+        assert "hook symlink:       MISSING" in r.stdout
+        assert "SessionStart entry: MISSING" in r.stdout
+
+    def test_check_passes_once_installed(self, repo: Path):
+        _run(repo, INSTALL_REFRESH)
+        r = _run(repo, INSTALL_REFRESH, "--check")
+        assert r.returncode == 0, r.stdout
+        assert "SessionStart entry: yes" in r.stdout
+
+    def test_the_half_install_is_caught(self, repo: Path):
+        """The #167 population: the symlink is right there, so only the
+        registration half distinguishes working from frozen."""
+        _half_install(repo)
+        r = _run(repo, INSTALL_REFRESH, "--check")
+        assert r.returncode == 3
+        assert "hook symlink:       .claude/hooks" in r.stdout
+        assert "SessionStart entry: MISSING" in r.stdout
+        assert "frozen" in r.stdout
+
+    def test_repairing_a_half_install_preserves_other_config(self, repo: Path):
+        """What the four repos actually had: an unrelated doctor hook wired by
+        hand. A repair that clobbers it trades one silent breakage for another."""
+        _half_install(
+            repo,
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                {"type": "command", "command": "bash .skills/doctor.sh"}
+                            ],
+                        }
+                    ]
+                },
+                "permissions": {"allow": ["Bash(ls:*)"]},
+            },
+        )
+        r = _run(repo, INSTALL_REFRESH)
+        assert r.returncode == 0, r.stderr
+        cmds = _commands(repo)
+        assert "bash .skills/doctor.sh" in cmds
+        assert any("skills-submodule-update.sh" in c for c in cmds)
+        assert _settings(repo)["permissions"] == {"allow": ["Bash(ls:*)"]}
+
+    def test_the_old_cwd_relative_form_is_not_duplicated(self, repo: Path):
+        """An install predating #110 is a real registration written differently.
+        Matching the whole command instead of the script path would append a
+        second entry and leave the first unremovable by the uninstall filter."""
+        _half_install(
+            repo,
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "bash .claude/hooks/skills-submodule-update.sh",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            },
+        )
+        r = _run(repo, INSTALL_REFRESH)
+        assert r.returncode == 0, r.stderr
+        hits = [c for c in _commands(repo) if "skills-submodule-update.sh" in c]
+        assert len(hits) == 1, hits
+
+    def test_a_legacy_entry_is_upgraded_not_left_alone(self, repo: Path):
+        """`--check` accepts the legacy cwd-relative form because it does run,
+        but the install path must still normalise it. Answering both questions
+        with one substring test made a re-run a no-op on exactly the repos
+        carrying the undocumented cwd assumption (#110) — usa-wa among them."""
+        _half_install(
+            repo,
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "bash .claude/hooks/skills-submodule-update.sh",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            },
+        )
+        # A legacy entry is a working hook, so --check must not call it broken.
+        chk = _run(repo, INSTALL_REFRESH, "--check")
+        assert "SessionStart entry: yes" in chk.stdout
+
+        r = _run(repo, INSTALL_REFRESH)
+        assert r.returncode == 0, r.stderr
+        assert "upgrading" in r.stdout
+        assert _commands(repo) == [
+            'bash "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/skills-submodule-update.sh"'
+        ]
+
+    def test_a_rerun_is_idempotent(self, repo: Path):
+        _run(repo, INSTALL_REFRESH)
+        before = (repo / SETTINGS_REL).read_text()
+        r = _run(repo, INSTALL_REFRESH)
+        assert r.returncode == 0
+        assert "unchanged" in r.stdout
+        assert (repo / SETTINGS_REL).read_text() == before
+
+    def test_a_dangling_symlink_is_not_reported_as_installed(self, repo: Path):
+        """Reporting a dangling link as present sends the operator looking
+        anywhere but at the submodule."""
+        _half_install(repo)
+        (repo / VENDOR_REL / "skills-submodule-update.sh").unlink()
+        r = _run(repo, INSTALL_REFRESH, "--check")
+        assert r.returncode == 3
+        assert "DANGLING" in r.stdout
+
+    def test_uninstall_removes_both_halves(self, repo: Path):
+        _half_install(
+            repo,
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                {"type": "command", "command": "bash .skills/doctor.sh"}
+                            ],
+                        }
+                    ]
+                }
+            },
+        )
+        _run(repo, INSTALL_REFRESH)
+        r = _run(repo, INSTALL_REFRESH, "--uninstall")
+        assert r.returncode == 0, r.stderr
+        assert not (repo / HOOK_REL).exists()
+        assert not (repo / HOOK_REL).is_symlink()
+        assert _commands(repo) == ["bash .skills/doctor.sh"]
+
+    def test_it_refuses_without_a_vendored_hook(self, tmp_path: Path):
+        bare = tmp_path / "bare"
+        bare.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=bare, check=True, env=_clean_env())
+        r = _run(bare, INSTALL_REFRESH)
+        assert r.returncode == 1
+        assert "no vendored" in r.stderr
+        assert not (bare / ".claude").exists()
+
+    def test_it_refuses_outside_a_git_repo(self, tmp_path: Path):
+        d = tmp_path / "nogit"
+        d.mkdir()
+        r = _run(d, INSTALL_REFRESH)
+        assert r.returncode == 1
+        assert "not inside a git repository" in r.stderr
+
+    def test_the_symlink_target_is_relative(self, repo: Path):
+        """An absolute target would break for every other checkout of the repo —
+        worktrees, CI clones, and anyone else's machine."""
+        _run(repo, INSTALL_REFRESH)
+        target = os.readlink(repo / HOOK_REL)
+        assert not os.path.isabs(target), target
+        assert target.startswith("../../")
+
+
+class TestDoctorReportsAHalfInstall:
+    """The doctor is the one code path that still runs in a repo whose refresh
+    hook does not — via a reviewing-*/shipping-* preflight, or a SessionStart
+    entry of its own, which is exactly what the four #167 repos had."""
+
+    def _doctor(self, repo: Path) -> subprocess.CompletedProcess:
+        installed = repo / ".skills" / "doctor.sh"
+        installed.parent.mkdir(parents=True, exist_ok=True)
+        installed.write_text(DOCTOR.read_text())
+        installed.chmod(0o755)
+        return _run(repo, installed)
+
+    def test_it_warns_without_changing_its_exit_code(self, repo: Path):
+        """Phase 1 preflights invoke the doctor with `|| exit 1`, so a wiring
+        gap must not block a review."""
+        _half_install(repo)
+        r = self._doctor(repo)
+        assert r.returncode == 0, r.stderr
+        assert "does not register it" in r.stderr
+        assert "install-refresh.sh" in r.stderr
+
+    def test_it_is_silent_when_the_hook_is_fully_installed(self, repo: Path):
+        _run(repo, INSTALL_REFRESH)
+        r = self._doctor(repo)
+        assert r.returncode == 0
+        assert "does not register it" not in r.stderr
+
+    def test_it_is_silent_when_the_hook_was_never_installed(self, repo: Path):
+        """A consumer that declined the hook is not broken. Nagging that group
+        trains everyone to ignore the warning that matters."""
+        r = self._doctor(repo)
+        assert r.returncode == 0
+        assert "does not register it" not in r.stderr


### PR DESCRIPTION
Fixes #167.

## The diagnosis in #167 was wrong in a way that matters

#167 said the four stale repos have "no refresh hook". Probing `.claude/hooks/` shows **all four have the symlink**, tracked and resolving. What they lack is the `.claude/settings.json` registration.

It is a **partial install**, not an absent one — and that is a worse failure than the one I filed, because the half that is missing is the half that would have run. Listing `.claude/hooks/` shows a hook that is right there and does nothing.

Their `settings.json` instead registers `bash .skills/doctor.sh`, a form this repo documents nowhere. Someone wanted session-start self-heal and wired the doctor directly, not knowing the refresh hook already installs the doctor on every session (SKILL.md's own behaviour list). So the doctor ran daily in all four repos while the pointer never moved.

## Root cause

Of the two installs in `managing-skills`, `install-doctor.sh` is a script and the refresh hook was a three-step procedure in SKILL.md. Only the prose one has a failure population. That is the whole difference.

So the prose is now a script.

## What is here

**`install-refresh.sh`** — idempotent, repairs a partial install, never commits. It treats the install as **two artifacts and reports them independently**, which is the lesson `install-cadence.sh` learned in #163: the symlink alone is precisely the state that reads as installed and does nothing. `--check` exits 0/3, `--uninstall` removes both halves.

`is_registered` and `is_current` are deliberately separate tests:

| | question | callers |
|---|---|---|
| `is_registered` | does the hook run **at all**? | `--check`, the doctor — a legacy cwd-relative entry (#110) *does* run, so calling it broken is how a warning gets ignored |
| `is_current` | is it in the form we now install? | the install path — so a re-run **upgrades** a legacy entry instead of seeing the substring and declaring victory |

I collapsed these into one test first, which made a re-run a no-op on exactly the repos carrying the undocumented cwd assumption. The **pre-existing #110 test caught it** — it asserts the install replaces a legacy entry. That test now drives the script rather than a jq block lifted out of SKILL.md; same rule, same home, implementation moved from prose to code.

**`doctor.sh` detection** — the doctor is the one code path that still runs in a repo whose refresh hook does not, which is the same reasoning that already puts `sync_self` there. It warns and **returns 0**: a wiring gap is not a dangling symlink and must not trip the `|| exit 1` in Phase 1 preflights. It stays silent when no symlink is present, so a consumer that deliberately declined the hook is never nagged.

Verified against a fixture reproducing the exact broken state, including the hand-wired `bash .skills/doctor.sh` entry and an unrelated `permissions` key — both survive the repair.

**SKILL.md** — the step-by-step is compressed, not deleted; the rationale moved into the script's comments, where somebody debugging it will actually be. That also had to pay for the new prose: the skill's own budget ratchet caught it at **9262 against 8750**, and a ratchet only ever comes down.

## Tests

`tests/structural/test_refresh_hook_install.py`, 16 cases: the #167 half-install, repair preserving unrelated hooks and keys, legacy-form upgrade, idempotency, dangling symlink, uninstall, no-vendor, non-git, relative-target — plus the three doctor cases (warns / silent when installed / silent when never installed).

`pytest tests/structural/` — **2224 passed, 127 skipped**.

## The cohort repair bootstraps itself

The four repos cannot run `install-refresh.sh` — their pinned commit predates it. They do not need to: their vendored `skills-submodule-update.sh` **exists at their pin** (verified at `3fc7b71e`), so adding the one registration entry is sufficient. The hook then bumps the submodule on the next session, which delivers `install-refresh.sh` and everything else.

Minimal repair, one entry, self-healing from there. Per-repo issues to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
