### PR TITLE
fix: protect every staged path, and stop the rebase diagnostic eating its own noun (#171, #173)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,8 @@
 # Append-only telemetry: concurrent appends must union-merge, or a
 # scheduled measurement racing a human commit conflicts and is lost.
 .skills/context-metrics.jsonl merge=union
+
+# Calibration is regenerated, never reconciled: on a collision keep
+# the branch's copy and let the next --exact run recompute it.
+.skills/context-token-ratio merge=ours
+.skills/context-token-counts merge=ours

--- a/.github/workflows/context-cadence.yml
+++ b/.github/workflows/context-cadence.yml
@@ -97,6 +97,12 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # `ours` is the one built-in merge driver git does NOT define for you:
+          # the .gitattributes entry alone is inert, and the calibration files
+          # would conflict exactly as if it were absent. `true` is the whole
+          # driver — it succeeds without writing, which leaves the branch's copy
+          # in place, and the next --exact run recomputes both (#173).
+          git config merge.ours.driver true
           # Staged separately, and the row is NOT tolerant of failure. One
           # `git add` over both paths stages NOTHING when either is missing —
           # it exits 128 on the unmatched pathspec — so `|| true` turned a
@@ -134,8 +140,22 @@ jobs:
             # the error line below, making "3 attempts" really one.
             git pull --rebase --autostash origin "$BRANCH" || {
               echo "::error::rebase onto origin/$BRANCH failed — the row was not pushed."
-              echo "::error::If the ledger conflicted, .gitattributes is missing"
-              echo "::error::`.skills/context-metrics.jsonl merge=union` — re-run install-cadence.sh."
+              # Name the file that actually conflicted rather than asserting it
+              # was the ledger. Blaming a ledger attribute that is present and
+              # correct sent the reader to the one file that was protected,
+              # while the calibration files were the unprotected ones (#173).
+              #
+              # \\` — escaped for BOTH layers. A single \` renders a live
+              # backtick into the workflow, where bash runs the attribute line
+              # as a command and the substitution eats the very filename this
+              # message exists to name (#171). The seams ::warning:: below has
+              # always had this right; this line did not.
+              git diff --name-only --diff-filter=U | sed 's/^/::error::  conflicted: /'
+              echo "::error::Re-run install-cadence.sh, then confirm with --check that"
+              echo "::error::every staged path carries a merge attribute:"
+              echo "::error::  \`.skills/context-metrics.jsonl merge=union\`"
+              echo "::error::  \`.skills/context-token-ratio merge=ours\`"
+              echo "::error::  \`.skills/context-token-counts merge=ours\`"
               exit 1
             }
           done

--- a/skills/curating-context/references/cadence.md
+++ b/skills/curating-context/references/cadence.md
@@ -214,6 +214,12 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # `ours` is the one built-in merge driver git does NOT define for you:
+          # the .gitattributes entry alone is inert, and the calibration files
+          # would conflict exactly as if it were absent. `true` is the whole
+          # driver — it succeeds without writing, which leaves the branch's copy
+          # in place, and the next --exact run recomputes both (#173).
+          git config merge.ours.driver true
           # Staged separately, and the row is NOT tolerant of failure. One
           # `git add` over both paths stages NOTHING when either is missing —
           # it exits 128 on the unmatched pathspec — so `|| true` turned a
@@ -251,8 +257,22 @@ jobs:
             # the error line below, making "3 attempts" really one.
             git pull --rebase --autostash origin "$BRANCH" || {
               echo "::error::rebase onto origin/$BRANCH failed — the row was not pushed."
-              echo "::error::If the ledger conflicted, .gitattributes is missing"
-              echo "::error::`.skills/context-metrics.jsonl merge=union` — re-run install-cadence.sh."
+              # Name the file that actually conflicted rather than asserting it
+              # was the ledger. Blaming a ledger attribute that is present and
+              # correct sent the reader to the one file that was protected,
+              # while the calibration files were the unprotected ones (#173).
+              #
+              # \\` — escaped for BOTH layers. A single \` renders a live
+              # backtick into the workflow, where bash runs the attribute line
+              # as a command and the substitution eats the very filename this
+              # message exists to name (#171). The seams ::warning:: below has
+              # always had this right; this line did not.
+              git diff --name-only --diff-filter=U | sed 's/^/::error::  conflicted: /'
+              echo "::error::Re-run install-cadence.sh, then confirm with --check that"
+              echo "::error::every staged path carries a merge attribute:"
+              echo "::error::  \`.skills/context-metrics.jsonl merge=union\`"
+              echo "::error::  \`.skills/context-token-ratio merge=ours\`"
+              echo "::error::  \`.skills/context-token-counts merge=ours\`"
               exit 1
             }
           done

--- a/skills/curating-context/scripts/install-cadence.sh
+++ b/skills/curating-context/scripts/install-cadence.sh
@@ -144,8 +144,29 @@ fi
 ATTR_FILE="$ROOT/.gitattributes"
 ATTR_LINE="$LEDGER merge=union"
 
+# The two calibration files the same --exact run rewrites (#145). The workflow
+# stages all THREE paths, so protecting only the ledger left the other two to
+# conflict on exactly the race the ledger was protected against (#173).
+#
+# merge=ours, not merge=union. Union-merging these produces two lines for the
+# same path with different counts, and the estimators would silently read
+# whichever they hit first — worse than a conflict, because nothing reports it.
+#
+# They are pure functions of the tree at measurement time, so the right answer
+# on a collision is always "recompute", never "reconcile". `ours` during a
+# rebase keeps whatever is already on the branch and drops the replayed
+# version; the next --exact run recomputes both from scratch. A week of stale
+# calibration is self-correcting. A lost row is not — it is a hole in the
+# series this whole mechanism exists to accumulate.
+RATIO_PATH=".skills/context-token-ratio"
+COUNTS_PATH=".skills/context-token-counts"
+ATTR_RATIO="$RATIO_PATH merge=ours"
+ATTR_COUNTS="$COUNTS_PATH merge=ours"
+
 ATTR_NOTE_1="# Append-only telemetry: concurrent appends must union-merge, or a"
 ATTR_NOTE_2="# scheduled measurement racing a human commit conflicts and is lost."
+ATTR_NOTE_3="# Calibration is regenerated, never reconciled: on a collision keep"
+ATTR_NOTE_4="# the branch's copy and let the next --exact run recompute it."
 
 # Remove OUR block for a given ledger: the attribute line and the two comment
 # lines that introduce it. Factored rather than inlined twice — a superseded
@@ -153,9 +174,10 @@ ATTR_NOTE_2="# scheduled measurement racing a human commit conflicts and is lost
 # second time is the duplication the last three rounds kept finding.
 strip_attr() {
   [ -f "$ATTR_FILE" ] || return 0
-  awk -v want="$1" -v n1="$ATTR_NOTE_1" -v n2="$ATTR_NOTE_2" '
+  awk -v want="$1" -v n1="$ATTR_NOTE_1" -v n2="$ATTR_NOTE_2" \
+      -v n3="$ATTR_NOTE_3" -v n4="$ATTR_NOTE_4" '
     { line = $0; sub(/^[ \t]+/, "", line) }
-    line == n1 || line == n2 { next }
+    line == n1 || line == n2 || line == n3 || line == n4 { next }
     line !~ /^#/ && index(line, want) == 1 { next }
     { print }
   ' "$ATTR_FILE" >"$ATTR_FILE.tmp" && mv -f "$ATTR_FILE.tmp" "$ATTR_FILE"
@@ -171,12 +193,31 @@ strip_attr() {
 # and the failure landed later as a row lost to a race.
 has_attr() {
   [ -f "$ATTR_FILE" ] || return 1
-  awk -v want="$ATTR_LINE" '
+  awk -v want="$1" '
     { line = $0; sub(/^[ \t]+/, "", line) }
     line ~ /^#/ { next }
     index(line, want) == 1 { found = 1; exit }
     END { exit !found }
   ' "$ATTR_FILE"
+}
+
+# Every path the rendered workflow stages, paired with the attribute that keeps
+# a concurrent commit from destroying it. Iterated rather than checked one by
+# one, so adding a staged path to the template and forgetting its attribute is
+# a diff in ONE list instead of a silent gap between two places — which is
+# exactly how the calibration files went unprotected for #145's whole life.
+ATTR_ALL="$ATTR_LINE
+$ATTR_RATIO
+$ATTR_COUNTS"
+
+has_all_attrs() {
+  local line
+  while IFS= read -r line; do
+    has_attr "$line" || return 1
+  done <<EOF
+$ATTR_ALL
+EOF
+  return 0
 }
 
 if [ "$MODE" = "check" ]; then
@@ -192,11 +233,23 @@ if [ "$MODE" = "check" ]; then
     echo "workflow:           MISSING ($WF_PATH)"
     rc=3
   fi
-  if has_attr; then
+  if has_attr "$ATTR_LINE"; then
     echo "ledger union merge: yes ($ATTR_LINE)"
   else
     echo "ledger union merge: MISSING — concurrent appends will conflict and the"
     echo "                    row is lost. Re-run install-cadence.sh to add it."
+    rc=3
+  fi
+  # Reported as its own line, not folded into the one above. The workflow
+  # stages three paths and each is a separate way to lose the row; a single
+  # "attributes: ok" would have read green through the whole of #173.
+  if has_attr "$ATTR_RATIO" && has_attr "$ATTR_COUNTS"; then
+    echo "calibration merge:  yes (regenerate-on-collision for both)"
+  else
+    echo "calibration merge:  MISSING — the workflow also stages"
+    echo "                    $RATIO_PATH and $COUNTS_PATH,"
+    echo "                    which conflict on the same race the ledger is"
+    echo "                    protected against. Re-run install-cadence.sh."
     rc=3
   fi
   exit "$rc"
@@ -209,10 +262,17 @@ if [ "$MODE" = "uninstall" ]; then
   else
     echo "nothing to remove: no $WF_PATH"
   fi
-  if has_attr; then
-    strip_attr "$ATTR_LINE"
-    echo "removed the .gitattributes union merge for $LEDGER"
-  fi
+  # Every attribute this installer wrote, not just the ledger's — an uninstall
+  # that leaves two of the three behind is the same half-state --check exists
+  # to catch.
+  while IFS= read -r attr; do
+    if has_attr "$attr"; then
+      strip_attr "$attr"
+      echo "removed the .gitattributes entry: $attr"
+    fi
+  done <<EOF
+$ATTR_ALL
+EOF
   echo "note: the recorded rows were left in place — they are the series."
   exit 0
 fi
@@ -261,8 +321,8 @@ ensure_attr() {
       echo "removed superseded .gitattributes line: $stale"
     fi
   fi
-  if has_attr; then
-    echo "unchanged: .gitattributes already carries the union merge for the ledger"
+  if has_all_attrs; then
+    echo "unchanged: .gitattributes already protects all three staged paths"
     return 0
   fi
   # Append rather than overwrite: the file routinely carries linguist and
@@ -270,10 +330,23 @@ ensure_attr() {
   if [ -s "$ATTR_FILE" ] && [ "$(tail -c 1 "$ATTR_FILE" | wc -l)" -eq 0 ]; then
     printf '\n' >>"$ATTR_FILE"
   fi
-  {
-    printf '\n%s\n%s\n%s\n' "$ATTR_NOTE_1" "$ATTR_NOTE_2" "$ATTR_LINE"
-  } >>"$ATTR_FILE"
-  echo "wrote .gitattributes: $ATTR_LINE"
+  # Each line appended only if absent, so a repo that installed before the
+  # calibration attributes existed (#173) gains exactly the two it is missing
+  # rather than a duplicated ledger line beside them. That population is every
+  # repo the cohort adopted between #145 and this fix.
+  if ! has_attr "$ATTR_LINE"; then
+    printf '\n%s\n%s\n%s\n' "$ATTR_NOTE_1" "$ATTR_NOTE_2" "$ATTR_LINE" >>"$ATTR_FILE"
+    echo "wrote .gitattributes: $ATTR_LINE"
+  fi
+  if ! has_attr "$ATTR_RATIO" || ! has_attr "$ATTR_COUNTS"; then
+    printf '\n%s\n%s\n' "$ATTR_NOTE_3" "$ATTR_NOTE_4" >>"$ATTR_FILE"
+    for attr in "$ATTR_RATIO" "$ATTR_COUNTS"; do
+      if ! has_attr "$attr"; then
+        printf '%s\n' "$attr" >>"$ATTR_FILE"
+        echo "wrote .gitattributes: $attr"
+      fi
+    done
+  fi
 }
 
 render() {
@@ -377,6 +450,12 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # \`ours\` is the one built-in merge driver git does NOT define for you:
+          # the .gitattributes entry alone is inert, and the calibration files
+          # would conflict exactly as if it were absent. \`true\` is the whole
+          # driver — it succeeds without writing, which leaves the branch's copy
+          # in place, and the next --exact run recomputes both (#173).
+          git config merge.ours.driver true
           # Staged separately, and the row is NOT tolerant of failure. One
           # \`git add\` over both paths stages NOTHING when either is missing —
           # it exits 128 on the unmatched pathspec — so \`|| true\` turned a
@@ -414,8 +493,22 @@ jobs:
             # the error line below, making "3 attempts" really one.
             git pull --rebase --autostash origin "\$BRANCH" || {
               echo "::error::rebase onto origin/\$BRANCH failed — the row was not pushed."
-              echo "::error::If the ledger conflicted, .gitattributes is missing"
-              echo "::error::\`$ATTR_LINE\` — re-run install-cadence.sh."
+              # Name the file that actually conflicted rather than asserting it
+              # was the ledger. Blaming a ledger attribute that is present and
+              # correct sent the reader to the one file that was protected,
+              # while the calibration files were the unprotected ones (#173).
+              #
+              # \\\\\` — escaped for BOTH layers. A single \\\` renders a live
+              # backtick into the workflow, where bash runs the attribute line
+              # as a command and the substitution eats the very filename this
+              # message exists to name (#171). The seams ::warning:: below has
+              # always had this right; this line did not.
+              git diff --name-only --diff-filter=U | sed 's/^/::error::  conflicted: /'
+              echo "::error::Re-run install-cadence.sh, then confirm with --check that"
+              echo "::error::every staged path carries a merge attribute:"
+              echo "::error::  \\\`$ATTR_LINE\\\`"
+              echo "::error::  \\\`$ATTR_RATIO\\\`"
+              echo "::error::  \\\`$ATTR_COUNTS\\\`"
               exit 1
             }
           done

--- a/tests/structural/test_cadence_rendered_shell.py
+++ b/tests/structural/test_cadence_rendered_shell.py
@@ -1,0 +1,223 @@
+"""Assertions on the cadence workflow as RENDERED, not as written (#171, #173).
+
+Both defects the usa-wa pilot found share one shape: generated shell was only
+ever checked at the layer it was typed in.
+
+#171 — `install-cadence.sh` escaped a backtick pair for its own heredoc but not
+for the workflow's bash, so the rendered YAML handed bash a live command
+substitution. The `::error::` that names the missing .gitattributes line ran the
+attribute as a command and printed the message without its noun. It sits on the
+rebase-failure branch, so no run reached it: green everywhere, wrong when read.
+
+#173 — the rendered `Commit the row` step stages three paths and the installer
+protected one. The two calibration files (#145) were added to the template
+without revisiting the attribute, so the race the ledger was protected against
+landed on them instead.
+
+Neither is visible in the installer source. Both are obvious in its output, so
+these tests read the output — `--print` it, pull the `run:` blocks out of the
+YAML, and check the shell that will actually execute.
+
+Coverage:
+- every `run:` block parses under `bash -n`
+- no live command substitution survives into a run block (heredoc bodies
+  excluded — a backtick there is literal, which is why the neighbouring
+  Python heredoc was always correct)
+- the rebase-failure diagnostic still names its attribute lines after rendering
+- every path the workflow `git add`s carries a merge attribute the installer
+  writes
+- --check reports the calibration attributes independently of the ledger's
+- a repo installed before #173 gains the two missing attributes without a
+  duplicated ledger line
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+INSTALL_CADENCE = (
+    REPO_ROOT / "skills" / "curating-context" / "scripts" / "install-cadence.sh"
+)
+
+LEDGER = ".skills/context-metrics.jsonl"
+RATIO = ".skills/context-token-ratio"
+COUNTS = ".skills/context-token-counts"
+
+
+def _repo(tmp_path: Path) -> Path:
+    # exist_ok because a test may also use the `rendered` fixture, which builds
+    # its own repo under the same tmp_path to run --print. That is harmless —
+    # --print writes nothing — and `git init` is idempotent.
+    r = tmp_path / "r"
+    r.mkdir(exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=r, check=True)
+    return r
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(INSTALL_CADENCE), *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+@pytest.fixture
+def rendered(tmp_path: Path) -> dict:
+    repo = _repo(tmp_path)
+    r = _run(repo, "--print", "--cron", "0 15 * * 1")
+    assert r.returncode == 0, r.stderr
+    return yaml.safe_load(r.stdout)
+
+
+def _run_blocks(doc: dict) -> list[tuple[str, str]]:
+    return [
+        (s.get("name", s.get("uses", "?")), s["run"])
+        for s in doc["jobs"]["measure"]["steps"]
+        if s.get("run")
+    ]
+
+
+def _strip_heredocs(script: str) -> list[str]:
+    """Lines outside heredoc bodies and outside comments.
+
+    A backtick inside `<<'PY'` is literal — the Python drift reporter has always
+    had one and has always been correct. Flagging it would make the real finding
+    indistinguishable from the noise beside it.
+    """
+    out, terminator = [], None
+    for line in script.splitlines():
+        if terminator is not None:
+            if line.strip() == terminator:
+                terminator = None
+            continue
+        m = re.search(r"<<-?\s*'?([A-Za-z_][A-Za-z0-9_]*)'?", line)
+        if m:
+            terminator = m.group(1)
+            continue
+        if line.lstrip().startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+class TestRenderedShellIsValid:
+    def test_every_run_block_parses(self, rendered: dict):
+        for name, script in _run_blocks(rendered):
+            r = subprocess.run(["bash", "-n"], input=script, capture_output=True,
+                               text=True)
+            assert r.returncode == 0, f"{name}: {r.stderr}"
+
+    def test_no_live_command_substitution_survives(self, rendered: dict):
+        """The #171 class. An unescaped backtick in a rendered run block is bash
+        command substitution, whatever it looked like in the installer."""
+        offenders = []
+        for name, script in _run_blocks(rendered):
+            for line in _strip_heredocs(script):
+                if re.search(r"(?<!\\)`", line):
+                    offenders.append(f"{name}: {line.strip()}")
+        assert not offenders, "live backticks in rendered shell:\n" + "\n".join(
+            offenders
+        )
+
+    def test_the_rebase_diagnostic_still_names_its_attributes(self, rendered: dict):
+        """#171's actual damage: the message survived, its noun did not. Assert
+        on the shell's OUTPUT, since the bug was invisible in its source."""
+        commit = dict(_run_blocks(rendered))["Commit the row"]
+        errors = [ln for ln in commit.splitlines() if "::error::" in ln and "merge=" in ln]
+        assert len(errors) == 3, errors
+        for line in errors:
+            printed = subprocess.run(
+                ["bash", "-c", line.strip()], capture_output=True, text=True
+            )
+            assert printed.returncode == 0, printed.stderr
+            assert "merge=" in printed.stdout, (
+                f"the attribute was eaten before printing: {printed.stdout!r}"
+            )
+
+
+class TestEveryStagedPathIsProtected:
+    """#173. The template staged three paths and the installer protected one.
+    Compare the two lists rather than trusting them to be edited together."""
+
+    def _staged(self, doc: dict) -> set[str]:
+        commit = dict(_run_blocks(doc))["Commit the row"]
+        return set(re.findall(r'git add -- "?([^"\s]+)"?', commit))
+
+    def test_the_workflow_stages_the_three_known_paths(self, rendered: dict):
+        """Pins the input to the test below — if the template gains a fourth
+        staged path, this fails first and says so, rather than the coverage
+        silently narrowing to whatever the regex still matched."""
+        assert self._staged(rendered) == {LEDGER, RATIO, COUNTS}
+
+    def test_every_staged_path_gets_a_merge_attribute(self, tmp_path: Path,
+                                                      rendered: dict):
+        repo = _repo(tmp_path)
+        assert _run(repo).returncode == 0
+        attrs = (repo / ".gitattributes").read_text()
+        declared = {
+            ln.split()[0]
+            for ln in attrs.splitlines()
+            if ln.strip() and not ln.startswith("#")
+        }
+        missing = self._staged(rendered) - declared
+        assert not missing, f"staged but unprotected: {sorted(missing)}\n{attrs}"
+
+    def test_calibration_uses_ours_not_union(self, tmp_path: Path):
+        """Union-merging these produces two lines for one path with different
+        counts, and the estimators read whichever they hit first — worse than a
+        conflict, because nothing reports it."""
+        repo = _repo(tmp_path)
+        _run(repo)
+        attrs = (repo / ".gitattributes").read_text()
+        assert f"{RATIO} merge=ours" in attrs
+        assert f"{COUNTS} merge=ours" in attrs
+        assert f"{LEDGER} merge=union" in attrs
+
+    def test_the_ours_driver_is_defined_in_the_workflow(self, rendered: dict):
+        """`ours` is the one built-in git does NOT define. Without this the
+        attribute is inert and the files conflict exactly as before."""
+        commit = dict(_run_blocks(rendered))["Commit the row"]
+        assert "git config merge.ours.driver true" in commit
+
+
+class TestCheckAndRepair:
+    def test_check_reports_calibration_separately(self, tmp_path: Path):
+        repo = _repo(tmp_path)
+        _run(repo)
+        r = _run(repo, "--check")
+        assert r.returncode == 0, r.stdout
+        assert "ledger union merge: yes" in r.stdout
+        assert "calibration merge:  yes" in r.stdout
+
+    def test_a_pre_173_install_is_repaired_without_duplication(self, tmp_path: Path):
+        """Every repo that adopted between #145 and this fix has the ledger line
+        and neither calibration line. Re-running must add exactly the two that
+        are missing."""
+        repo = _repo(tmp_path)
+        (repo / ".gitattributes").write_text(f"{LEDGER} merge=union\n")
+        r = _run(repo, "--check")
+        assert r.returncode == 3
+        assert "calibration merge:  MISSING" in r.stdout
+
+        assert _run(repo).returncode == 0
+        attrs = (repo / ".gitattributes").read_text()
+        assert attrs.count(f"{LEDGER} merge=union") == 1, attrs
+        assert attrs.count(f"{RATIO} merge=ours") == 1, attrs
+        assert attrs.count(f"{COUNTS} merge=ours") == 1, attrs
+        assert _run(repo, "--check").returncode == 0
+
+    def test_uninstall_removes_all_three(self, tmp_path: Path):
+        repo = _repo(tmp_path)
+        (repo / ".gitattributes").write_text("*.png binary\n")
+        _run(repo)
+        assert _run(repo, "--uninstall").returncode == 0
+        attrs = (repo / ".gitattributes").read_text()
+        assert "merge=" not in attrs, attrs
+        assert "*.png binary" in attrs, "unrelated rules must survive"

--- a/tests/structural/test_context_surface.py
+++ b/tests/structural/test_context_surface.py
@@ -3527,19 +3527,23 @@ class TestCadenceDescribesTheRepoNotTheInvocation:
             self, tmp_path: Path):
         r = self._run(self._repo(tmp_path), "--uninstall")
         assert r.returncode == 0
-        assert "removed the .gitattributes union merge" not in r.stdout
+        assert "removed the .gitattributes entry" not in r.stdout
         assert "recorded rows were left in place" in r.stdout
 
-    def test_uninstall_removes_the_attribute_it_installed(self, tmp_path: Path):
+    def test_uninstall_removes_the_attributes_it_installed(self, tmp_path: Path):
         """The installer's contract is two artifacts, so uninstall reverses
         both. The rows stay — removing the mechanism that adds to the series is
-        not a reason to discard what it already collected."""
+        not a reason to discard what it already collected.
+
+        All THREE attribute lines, not just the ledger's: an uninstall that
+        leaves the calibration entries behind is the same half-state --check
+        exists to catch (#173)."""
         repo = self._repo(tmp_path)
         self._run(repo)
         assert (repo / ".gitattributes").exists()
         r = self._run(repo, "--uninstall")
         assert r.returncode == 0, r.stderr
-        assert "removed the .gitattributes union merge" in r.stdout
+        assert r.stdout.count("removed the .gitattributes entry") == 3, r.stdout
         # The file was ours, so it goes with it.
         assert not (repo / ".gitattributes").exists(), (
             repo / ".gitattributes").read_text()


### PR DESCRIPTION
Fixes #171. Fixes #173.

Both found piloting the cadence in [CannObserv/usa-wa#221](https://github.com/CannObserv/usa-wa/issues/221), and both are the same shape: **generated shell was only ever checked at the layer it was typed in.** So the fixes come with pins that assert the *rendered* artifact.

## #171 — the diagnostic ate its own noun

The installer escaped a backtick pair for its own heredoc but not for the workflow's bash, so the rendered YAML handed bash a live command substitution. Reproduced:

```
$ bash -c 'echo "::error::`.skills/context-metrics.jsonl merge=union` — re-run install-cadence.sh."'
bash: .skills/context-metrics.jsonl: Permission denied
::error:: — re-run install-cadence.sh.
```

It sits on the rebase-failure branch, so no run reached it: green everywhere, wrong when read once under pressure.

The message now also **lists the conflicted paths from git** instead of asserting it was the ledger — blaming a ledger attribute that was present and correct sent the reader to the one file that *was* protected.

## #173 — three staged paths, one protected

`merge=ours`, not `merge=union`. Union-merging the calibration files yields two lines for one path with different counts and the estimators read whichever they hit first — worse than a conflict, because nothing reports it. They are pure functions of the tree, so the answer on collision is always *recompute*, never *reconcile*: a week of stale calibration is self-correcting, a lost row is a hole in the series.

`ours` is the one built-in driver **git does not define for you**, so the workflow now sets `merge.ours.driver=true`. Without it the attribute is inert and the files conflict exactly as before — that is the failure mode this issue is about, so it gets an assertion rather than a comment.

`ensure_attr` appends each line only if absent, so every repo that adopted between #145 and now gains exactly the two it is missing rather than a duplicated ledger line beside them. **Verified live**: this repo had only the ledger entry and came out with three, no duplication, `--check` exit 0.

`--check` reports calibration on its own line. A single `attributes: ok` would have read green through the whole of #173.

## The pins

`tests/structural/test_cadence_rendered_shell.py`, 10 cases. `--print` the workflow, pull the `run:` blocks out of the YAML, `bash -n` each one, and reject any live backtick surviving outside a heredoc body — heredoc-aware because the neighbouring Python reporter has always had a literal backtick and has always been correct.

For #173 it diffs *what the template stages* against *what the installer protects*, which is precisely the drift that opened the gap, and pins the staged set so a fourth path fails loudly instead of silently narrowing the check.

**Both bugs were reintroduced to confirm the tests fail on them** — #171 → 2 failures, #173 → 5. Regression tests that pass on the bug are decoration.

`pytest tests/structural/` — 2234 passed, 127 skipped.

## Incidental

Exercising the drift reporter by hand ran the **over-budget `::warning::` branch**, which usa-wa correctly noted no pilot had reached (both pilot repos measured under budget). It renders and prints correctly.

## For the eleven gated repos

Both fixes land in generated output, so every cohort repo inherits them at pin bump — no hand-patching. `usa-wa` should re-run `install-cadence.sh` after bumping; it will report `updated:` for the workflow and write the two missing attribute lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
